### PR TITLE
Minor revision of the Shaft class

### DIFF
--- a/bladex/shaft.py
+++ b/bladex/shaft.py
@@ -29,13 +29,15 @@ class Shaft(object):
         :rtype: OCC.Core.TopoDS.TopoDS_Solid
         """
         ext = os.path.splitext(self.filename)[1][1:]
-        if ext=='stl':
+        if ext == 'stl':
         	shaft_compound = read_stl_file(self.filename)
-        elif ext=='iges':
+        elif ext == 'iges':
         	iges_reader = IGESControl_Reader()
         	iges_reader.ReadFile(self.filename)
         	iges_reader.TransferRoots()
         	shaft_compound = iges_reader.Shape()
+        else:
+        	raise Exception('The shaft file is not in iges/stl formats')
         sewer = BRepBuilderAPI_Sewing(1e-2)
         sewer.Add(shaft_compound)
         sewer.Perform()

--- a/bladex/shaft.py
+++ b/bladex/shaft.py
@@ -1,5 +1,6 @@
 import os
 from OCC.Core.IGESControl import IGESControl_Reader
+from OCC.Extend.DataExchange import read_stl_file
 from OCC.Core.BRepBuilderAPI import BRepBuilderAPI_MakeSolid, BRepBuilderAPI_Sewing
 import OCC.Core.TopoDS
 from OCC.Display.SimpleGui import init_display
@@ -8,9 +9,9 @@ class Shaft(object):
     """
     Bottom-up parametrized shaft construction.
 
-    :param string filename: path (with the file extension) of a .iges file with 
+    :param string filename: path (with the file extension) of a .stl or .iges file with 
         stored shaft information.
-    :cvar string filename: path (with the file extension) of a .iges file with 
+    :cvar string filename: path (with the file extension) of a .stl or .iges file with 
         stored shaft information.
     """
 
@@ -27,10 +28,14 @@ class Shaft(object):
         :return: solid shaft
         :rtype: OCC.Core.TopoDS.TopoDS_Solid
         """
-        iges_reader = IGESControl_Reader()
-        iges_reader.ReadFile(self.filename)
-        iges_reader.TransferRoots()
-        shaft_compound = iges_reader.Shape()
+        ext = os.path.splitext(self.filename)[1][1:]
+        if ext=='stl':
+        	shaft_compound = read_stl_file(self.filename)
+        elif ext=='iges':
+        	iges_reader = IGESControl_Reader()
+        	iges_reader.ReadFile(self.filename)
+        	iges_reader.TransferRoots()
+        	shaft_compound = iges_reader.Shape()
         sewer = BRepBuilderAPI_Sewing(1e-2)
         sewer.Add(shaft_compound)
         sewer.Perform()

--- a/tests/test_datasets/shaft.stl
+++ b/tests/test_datasets/shaft.stl
@@ -1,0 +1,8171 @@
+solid 
+ facet normal -1.332393e-01  1.695494e-01 -9.764734e-01
+   outer loop
+     vertex -8.647252e+01  9.431689e+00 -2.634089e+01
+     vertex -2.800000e+01  2.050521e-05 -3.595710e+01
+     vertex -1.449450e+02  4.657024e-05 -2.000000e+01
+   endloop
+ endfacet
+ facet normal -1.423199e-01  8.693457e-01 -4.732685e-01
+   outer loop
+     vertex -1.254542e+02  1.967836e+01 -1.123458e+01
+     vertex -1.449450e+02  1.627649e+01 -1.162224e+01
+     vertex -1.449450e+02  1.859573e+01 -7.362030e+00
+   endloop
+ endfacet
+ facet normal -1.326005e-01  8.227183e-01 -5.527673e-01
+   outer loop
+     vertex -1.254542e+02  1.967836e+01 -1.123458e+01
+     vertex -1.254542e+02  1.783884e+01 -1.397245e+01
+     vertex -1.449450e+02  1.627649e+01 -1.162224e+01
+   endloop
+ endfacet
+ facet normal -1.360757e-01  8.894981e-01 -4.362071e-01
+   outer loop
+     vertex -1.254542e+02  2.093105e+01 -8.680147e+00
+     vertex -1.254542e+02  1.967836e+01 -1.123458e+01
+     vertex -1.449450e+02  1.859573e+01 -7.362030e+00
+   endloop
+ endfacet
+ facet normal -1.331645e-01  7.960524e-01 -5.903964e-01
+   outer loop
+     vertex -1.157088e+02  1.993833e+01 -1.333972e+01
+     vertex -1.157088e+02  1.855302e+01 -1.520759e+01
+     vertex -1.254542e+02  1.783884e+01 -1.397245e+01
+   endloop
+ endfacet
+ facet normal -1.411831e-01  8.217338e-01 -5.521059e-01
+   outer loop
+     vertex -1.157088e+02  1.993833e+01 -1.333972e+01
+     vertex -1.254542e+02  1.783884e+01 -1.397245e+01
+     vertex -1.254542e+02  1.967836e+01 -1.123458e+01
+   endloop
+ endfacet
+ facet normal -1.375218e-01  8.893188e-01 -4.361191e-01
+   outer loop
+     vertex -1.157088e+02  2.107359e+01 -1.146250e+01
+     vertex -1.254542e+02  1.967836e+01 -1.123458e+01
+     vertex -1.254542e+02  2.093105e+01 -8.680147e+00
+   endloop
+ endfacet
+ facet normal -1.334073e-01  8.480434e-01 -5.128596e-01
+   outer loop
+     vertex -1.157088e+02  2.107359e+01 -1.146250e+01
+     vertex -1.157088e+02  1.993833e+01 -1.333972e+01
+     vertex -1.254542e+02  1.967836e+01 -1.123458e+01
+   endloop
+ endfacet
+ facet normal -1.426778e-01  8.280335e-01  5.422209e-01
+   outer loop
+     vertex -1.254542e+02  1.887872e+01  1.253187e+01
+     vertex -1.449450e+02  1.794793e+01  8.824549e+00
+     vertex -1.449450e+02  1.526383e+01  1.292347e+01
+   endloop
+ endfacet
+ facet normal -1.333118e-01  8.650257e-01  4.836927e-01
+   outer loop
+     vertex -1.254542e+02  1.887872e+01  1.253187e+01
+     vertex -1.254542e+02  2.056178e+01  9.521907e+00
+     vertex -1.449450e+02  1.794793e+01  8.824549e+00
+   endloop
+ endfacet
+ facet normal -1.322090e-01  7.792175e-01  6.126508e-01
+   outer loop
+     vertex -1.254542e+02  1.663268e+01  1.538856e+01
+     vertex -1.254542e+02  1.887872e+01  1.253187e+01
+     vertex -1.449450e+02  1.526383e+01  1.292347e+01
+   endloop
+ endfacet
+ facet normal -1.406558e-01  8.641392e-01  4.831970e-01
+   outer loop
+     vertex -1.157088e+02  2.057506e+01  1.233500e+01
+     vertex -1.254542e+02  2.056178e+01  9.521907e+00
+     vertex -1.254542e+02  1.887872e+01  1.253187e+01
+   endloop
+ endfacet
+ facet normal -1.316388e-01  8.207720e-01  5.558818e-01
+   outer loop
+     vertex -1.157088e+02  1.908949e+01  1.452848e+01
+     vertex -1.157088e+02  2.057506e+01  1.233500e+01
+     vertex -1.254542e+02  1.887872e+01  1.253187e+01
+   endloop
+ endfacet
+ facet normal -1.421725e-01  7.781326e-01  6.117978e-01
+   outer loop
+     vertex -1.157088e+02  1.908949e+01  1.452848e+01
+     vertex -1.254542e+02  1.887872e+01  1.253187e+01
+     vertex -1.254542e+02  1.663268e+01  1.538856e+01
+   endloop
+ endfacet
+ facet normal -1.325763e-01  7.519527e-01  6.457481e-01
+   outer loop
+     vertex -1.157088e+02  1.724606e+01  1.667509e+01
+     vertex -1.157088e+02  1.908949e+01  1.452848e+01
+     vertex -1.254542e+02  1.663268e+01  1.538856e+01
+   endloop
+ endfacet
+ facet normal -1.393641e-01  9.047967e-02  9.860989e-01
+   outer loop
+     vertex -1.254542e+02  2.008286e+00  2.257035e+01
+     vertex -1.449450e+02  3.639617e+00  1.966605e+01
+     vertex -1.449450e+02  2.433692e-13  2.000000e+01
+   endloop
+ endfacet
+ facet normal -1.399773e-01 -1.108589e-01  9.839292e-01
+   outer loop
+     vertex -1.254542e+02 -1.377995e+00  2.261758e+01
+     vertex -1.449450e+02  2.433692e-13  2.000000e+01
+     vertex -1.449450e+02 -4.450291e+00  1.949859e+01
+   endloop
+ endfacet
+ facet normal -1.321301e-01  1.382458e-02  9.911360e-01
+   outer loop
+     vertex -1.254542e+02 -1.377995e+00  2.261758e+01
+     vertex -1.254542e+02  2.008286e+00  2.257035e+01
+     vertex -1.449450e+02  2.433692e-13  2.000000e+01
+   endloop
+ endfacet
+ facet normal -1.359626e-01 -1.339769e-01  9.816131e-01
+   outer loop
+     vertex -1.254542e+02 -4.733482e+00  2.215960e+01
+     vertex -1.254542e+02 -1.377995e+00  2.261758e+01
+     vertex -1.449450e+02 -4.450291e+00  1.949859e+01
+   endloop
+ endfacet
+ facet normal -1.428233e-01  1.861604e-01  9.720832e-01
+   outer loop
+     vertex -1.157088e+02  3.183957e+00  2.377704e+01
+     vertex -1.157088e+02  5.826065e+00  2.327106e+01
+     vertex -1.254542e+02  2.008286e+00  2.257035e+01
+   endloop
+ endfacet
+ facet normal -1.315830e-01  7.627363e-02  9.883665e-01
+   outer loop
+     vertex -1.157088e+02  5.018317e-01  2.398403e+01
+     vertex -1.157088e+02  3.183957e+00  2.377704e+01
+     vertex -1.254542e+02  2.008286e+00  2.257035e+01
+   endloop
+ endfacet
+ facet normal -1.414542e-01  1.380662e-02  9.898485e-01
+   outer loop
+     vertex -1.157088e+02  5.018317e-01  2.398403e+01
+     vertex -1.254542e+02  2.008286e+00  2.257035e+01
+     vertex -1.254542e+02 -1.377995e+00  2.261758e+01
+   endloop
+ endfacet
+ facet normal -1.411540e-01 -3.269630e-01  9.344361e-01
+   outer loop
+     vertex -1.254542e+02 -7.983237e+00  2.120664e+01
+     vertex -1.449450e+02 -4.450291e+00  1.949859e+01
+     vertex -1.449450e+02 -8.677438e+00  1.801949e+01
+   endloop
+ endfacet
+ facet normal -1.338819e-01 -2.788579e-01  9.509542e-01
+   outer loop
+     vertex -1.254542e+02 -7.983237e+00  2.120664e+01
+     vertex -1.254542e+02 -4.733482e+00  2.215960e+01
+     vertex -1.449450e+02 -4.450291e+00  1.949859e+01
+   endloop
+ endfacet
+ facet normal -1.321736e-01 -3.486188e-02  9.906133e-01
+   outer loop
+     vertex -1.157088e+02 -2.186604e+00  2.388941e+01
+     vertex -1.157088e+02  5.018317e-01  2.398403e+01
+     vertex -1.254542e+02 -1.377995e+00  2.261758e+01
+   endloop
+ endfacet
+ facet normal -1.391605e-01 -1.339168e-01  9.811731e-01
+   outer loop
+     vertex -1.157088e+02 -2.186604e+00  2.388941e+01
+     vertex -1.254542e+02 -1.377995e+00  2.261758e+01
+     vertex -1.254542e+02 -4.733482e+00  2.215960e+01
+   endloop
+ endfacet
+ facet normal -1.399773e-01 -5.267803e-01  8.383966e-01
+   outer loop
+     vertex -1.254542e+02 -1.105467e+01  1.977999e+01
+     vertex -1.449450e+02 -8.677438e+00  1.801949e+01
+     vertex -1.449450e+02 -1.246949e+01  1.563687e+01
+   endloop
+ endfacet
+ facet normal -1.321301e-01 -4.175707e-01  8.989863e-01
+   outer loop
+     vertex -1.254542e+02 -1.105467e+01  1.977999e+01
+     vertex -1.254542e+02 -7.983237e+00  2.120664e+01
+     vertex -1.449450e+02 -8.677438e+00  1.801949e+01
+   endloop
+ endfacet
+ facet normal -1.359271e-01 -1.454784e-01  9.799795e-01
+   outer loop
+     vertex -1.157088e+02 -4.847544e+00  2.349440e+01
+     vertex -1.157088e+02 -2.186604e+00  2.388941e+01
+     vertex -1.254542e+02 -4.733482e+00  2.215960e+01
+   endloop
+ endfacet
+ facet normal -1.359626e-01 -5.466041e-01  8.262797e-01
+   outer loop
+     vertex -1.254542e+02 -1.387917e+01  1.791151e+01
+     vertex -1.254542e+02 -1.105467e+01  1.977999e+01
+     vertex -1.449450e+02 -1.246949e+01  1.563687e+01
+   endloop
+ endfacet
+ facet normal -1.404067e-01 -2.786037e-01  9.500873e-01
+   outer loop
+     vertex -1.157088e+02 -7.447527e+00  2.280394e+01
+     vertex -1.254542e+02 -4.733482e+00  2.215960e+01
+     vertex -1.254542e+02 -7.983237e+00  2.120664e+01
+   endloop
+ endfacet
+ facet normal -1.341584e-01 -2.543453e-01  9.577630e-01
+   outer loop
+     vertex -1.157088e+02 -7.447527e+00  2.280394e+01
+     vertex -1.157088e+02 -4.847544e+00  2.349440e+01
+     vertex -1.254542e+02 -4.733482e+00  2.215960e+01
+   endloop
+ endfacet
+ facet normal -1.182262e-01  7.909758e-01 -6.003165e-01
+   outer loop
+     vertex -4.749084e+01  2.867004e+01 -1.693393e+01
+     vertex -5.723626e+01  2.430817e+01 -2.076186e+01
+     vertex -5.723626e+01  2.653591e+01 -1.782660e+01
+   endloop
+ endfacet
+ facet normal -1.404946e-01  8.523031e-01 -5.038261e-01
+   outer loop
+     vertex -4.749084e+01  2.867004e+01 -1.693393e+01
+     vertex -5.723626e+01  2.653591e+01 -1.782660e+01
+     vertex -5.723626e+01  2.841106e+01 -1.465447e+01
+   endloop
+ endfacet
+ facet normal -1.315830e-01 -3.601039e-01  9.235860e-01
+   outer loop
+     vertex -1.157088e+02 -9.953858e+00  2.182673e+01
+     vertex -1.157088e+02 -7.447527e+00  2.280394e+01
+     vertex -1.254542e+02 -7.983237e+00  2.120664e+01
+   endloop
+ endfacet
+ facet normal -1.414541e-01 -4.170283e-01  8.978185e-01
+   outer loop
+     vertex -1.157088e+02 -9.953858e+00  2.182673e+01
+     vertex -1.254542e+02 -7.983237e+00  2.120664e+01
+     vertex -1.254542e+02 -1.105467e+01  1.977999e+01
+   endloop
+ endfacet
+ facet normal -1.411540e-01 -7.000109e-01  7.000430e-01
+   outer loop
+     vertex -1.254542e+02 -1.639365e+01  1.564295e+01
+     vertex -1.449450e+02 -1.246949e+01  1.563687e+01
+     vertex -1.449450e+02 -1.563630e+01  1.247021e+01
+   endloop
+ endfacet
+ facet normal -1.338819e-01 -6.638360e-01  7.357971e-01
+   outer loop
+     vertex -1.254542e+02 -1.639365e+01  1.564295e+01
+     vertex -1.254542e+02 -1.387917e+01  1.791151e+01
+     vertex -1.449450e+02 -1.246949e+01  1.563687e+01
+   endloop
+ endfacet
+ facet normal -1.387276e-01  8.888664e-01 -4.366591e-01
+   outer loop
+     vertex -4.749084e+01  3.092553e+01 -1.234263e+01
+     vertex -2.800000e+01  3.286914e+01 -1.457849e+01
+     vertex -4.749084e+01  2.867004e+01 -1.693393e+01
+   endloop
+ endfacet
+ facet normal -1.259722e-01  8.903951e-01 -4.374101e-01
+   outer loop
+     vertex -4.749084e+01  3.092553e+01 -1.234263e+01
+     vertex -4.749084e+01  2.867004e+01 -1.693393e+01
+     vertex -5.723626e+01  2.841106e+01 -1.465447e+01
+   endloop
+ endfacet
+ facet normal -1.282673e-01  9.468193e-01 -2.950943e-01
+   outer loop
+     vertex -4.749084e+01  3.092553e+01 -1.234263e+01
+     vertex -2.800000e+01  3.533161e+01 -6.677595e+00
+     vertex -2.800000e+01  3.286914e+01 -1.457849e+01
+   endloop
+ endfacet
+ facet normal -1.321737e-01 -4.612086e-01  8.773920e-01
+   outer loop
+     vertex -1.157088e+02 -1.233500e+01  2.057506e+01
+     vertex -1.157088e+02 -9.953858e+00  2.182673e+01
+     vertex -1.254542e+02 -1.105467e+01  1.977999e+01
+   endloop
+ endfacet
+ facet normal -1.391604e-01 -5.463591e-01  8.259093e-01
+   outer loop
+     vertex -1.157088e+02 -1.233500e+01  2.057506e+01
+     vertex -1.254542e+02 -1.105467e+01  1.977999e+01
+     vertex -1.254542e+02 -1.387917e+01  1.791151e+01
+   endloop
+ endfacet
+ facet normal -1.281026e-01  9.173367e-01  3.769392e-01
+   outer loop
+     vertex -4.749084e+01  2.974425e+01  1.496691e+01
+     vertex -2.800000e+01  3.146515e+01  1.740280e+01
+     vertex -2.800000e+01  3.461052e+01  9.748097e+00
+   endloop
+ endfacet
+ facet normal -1.259324e-01  8.493040e-01  5.126634e-01
+   outer loop
+     vertex -4.749084e+01  2.710073e+01  1.934630e+01
+     vertex -4.749084e+01  2.974425e+01  1.496691e+01
+     vertex -5.723626e+01  2.705053e+01  1.703557e+01
+   endloop
+ endfacet
+ facet normal -1.404947e-01  8.059856e-01  5.750204e-01
+   outer loop
+     vertex -4.749084e+01  2.710073e+01  1.934630e+01
+     vertex -5.723626e+01  2.705053e+01  1.703557e+01
+     vertex -5.723626e+01  2.491040e+01  2.003531e+01
+   endloop
+ endfacet
+ facet normal -1.184743e-01  7.365921e-01  6.658798e-01
+   outer loop
+     vertex -4.749084e+01  2.710073e+01  1.934630e+01
+     vertex -5.723626e+01  2.491040e+01  2.003531e+01
+     vertex -5.723626e+01  2.243929e+01  2.276884e+01
+   endloop
+ endfacet
+ facet normal -1.388168e-01  8.478308e-01  5.117742e-01
+   outer loop
+     vertex -4.749084e+01  2.710073e+01  1.934630e+01
+     vertex -2.800000e+01  3.146515e+01  1.740280e+01
+     vertex -4.749084e+01  2.974425e+01  1.496691e+01
+   endloop
+ endfacet
+ facet normal -1.232470e-01  8.073620e-01  5.770414e-01
+   outer loop
+     vertex -4.749084e+01  2.710073e+01  1.934630e+01
+     vertex -2.800000e+01  2.665302e+01  2.413565e+01
+     vertex -2.800000e+01  3.146515e+01  1.740280e+01
+   endloop
+ endfacet
+ facet normal -1.182556e-01  1.422744e-01  9.827378e-01
+   outer loop
+     vertex -4.749084e+01  9.374402e-01  3.328439e+01
+     vertex -5.723626e+01  6.396176e+00  3.132141e+01
+     vertex -5.723626e+01  2.749280e+00  3.184938e+01
+   endloop
+ endfacet
+ facet normal -1.404947e-01  2.815523e-02  9.896810e-01
+   outer loop
+     vertex -4.749084e+01  9.374402e-01  3.328439e+01
+     vertex -5.723626e+01  2.749280e+00  3.184938e+01
+     vertex -5.723626e+01 -9.341460e-01  3.195417e+01
+   endloop
+ endfacet
+ facet normal -1.380069e-01 -8.595262e-02  9.866946e-01
+   outer loop
+     vertex -4.749084e+01 -4.171877e+00  3.303520e+01
+     vertex -5.723626e+01 -9.341460e-01  3.195417e+01
+     vertex -5.723626e+01 -4.605160e+00  3.163439e+01
+   endloop
+ endfacet
+ facet normal -1.259674e-01 -4.832453e-02  9.908567e-01
+   outer loop
+     vertex -4.749084e+01 -4.171877e+00  3.303520e+01
+     vertex -4.749084e+01  9.374402e-01  3.328439e+01
+     vertex -5.723626e+01 -9.341460e-01  3.195417e+01
+   endloop
+ endfacet
+ facet normal -1.307498e-01 -1.991260e-01  9.712123e-01
+   outer loop
+     vertex -4.749084e+01 -4.171877e+00  3.303520e+01
+     vertex -5.723626e+01 -4.605160e+00  3.163439e+01
+     vertex -5.723626e+01 -8.214985e+00  3.089427e+01
+   endloop
+ endfacet
+ facet normal -1.387384e-01 -4.824146e-02  9.891534e-01
+   outer loop
+     vertex -4.749084e+01 -4.171877e+00  3.303520e+01
+     vertex -2.800000e+01 -3.150983e+00  3.581877e+01
+     vertex -4.749084e+01  9.374402e-01  3.328439e+01
+   endloop
+ endfacet
+ facet normal -1.282921e-01 -1.994664e-01  9.714702e-01
+   outer loop
+     vertex -4.749084e+01 -9.182733e+00  3.200635e+01
+     vertex -2.800000e+01 -3.150983e+00  3.581877e+01
+     vertex -4.749084e+01 -4.171877e+00  3.303520e+01
+   endloop
+ endfacet
+ facet normal -1.281023e-01 -2.000231e-01  9.713807e-01
+   outer loop
+     vertex -4.749084e+01 -9.182733e+00  3.200635e+01
+     vertex -2.800000e+01 -1.125665e+01  3.414968e+01
+     vertex -2.800000e+01 -3.150983e+00  3.581877e+01
+   endloop
+ endfacet
+ facet normal -1.380794e-01 -3.092578e-01  9.409005e-01
+   outer loop
+     vertex -4.749084e+01 -9.182733e+00  3.200635e+01
+     vertex -5.723626e+01 -8.214985e+00  3.089427e+01
+     vertex -5.723626e+01 -1.171566e+01  2.974366e+01
+   endloop
+ endfacet
+ facet normal -1.306251e-01 -1.994051e-01  9.711718e-01
+   outer loop
+     vertex -4.749084e+01 -9.182733e+00  3.200635e+01
+     vertex -4.749084e+01 -4.171877e+00  3.303520e+01
+     vertex -5.723626e+01 -8.214985e+00  3.089427e+01
+   endloop
+ endfacet
+ facet normal -1.232468e-01 -4.170674e-01  9.004804e-01
+   outer loop
+     vertex -4.749084e+01 -1.397687e+01  3.022212e+01
+     vertex -2.800000e+01 -1.876605e+01  3.067162e+01
+     vertex -2.800000e+01 -1.125665e+01  3.414968e+01
+   endloop
+ endfacet
+ facet normal -1.388166e-01 -3.454205e-01  9.281243e-01
+   outer loop
+     vertex -4.749084e+01 -1.397687e+01  3.022212e+01
+     vertex -2.800000e+01 -1.125665e+01  3.414968e+01
+     vertex -4.749084e+01 -9.182733e+00  3.200635e+01
+   endloop
+ endfacet
+ facet normal -1.404947e-01 -4.153376e-01  8.987524e-01
+   outer loop
+     vertex -4.749084e+01 -1.397687e+01  3.022212e+01
+     vertex -5.723626e+01 -1.171566e+01  2.974366e+01
+     vertex -5.723626e+01 -1.506066e+01  2.819784e+01
+   endloop
+ endfacet
+ facet normal -1.259324e-01 -3.460206e-01  9.297369e-01
+   outer loop
+     vertex -4.749084e+01 -1.397687e+01  3.022212e+01
+     vertex -4.749084e+01 -9.182733e+00  3.200635e+01
+     vertex -5.723626e+01 -1.171566e+01  2.974366e+01
+   endloop
+ endfacet
+ facet normal -1.380069e-01 -5.161871e-01  8.452839e-01
+   outer loop
+     vertex -4.749084e+01 -1.844113e+01  2.772461e+01
+     vertex -5.723626e+01 -1.506066e+01  2.819784e+01
+     vertex -5.723626e+01 -1.820555e+01  2.627736e+01
+   endloop
+ endfacet
+ facet normal -1.387383e-01 -4.835128e-01  8.642725e-01
+   outer loop
+     vertex -4.749084e+01 -1.844113e+01  2.772461e+01
+     vertex -2.800000e+01 -1.876605e+01  3.067162e+01
+     vertex -4.749084e+01 -1.397687e+01  3.022212e+01
+   endloop
+ endfacet
+ facet normal -1.259674e-01 -4.843454e-01  8.657608e-01
+   outer loop
+     vertex -4.749084e+01 -1.844113e+01  2.772461e+01
+     vertex -4.749084e+01 -1.397687e+01  3.022212e+01
+     vertex -5.723626e+01 -1.506066e+01  2.819784e+01
+   endloop
+ endfacet
+ facet normal -1.281024e-01 -6.115156e-01  7.807935e-01
+   outer loop
+     vertex -4.749084e+01 -2.247016e+01  2.457277e+01
+     vertex -2.800000e+01 -2.528137e+01  2.556884e+01
+     vertex -2.800000e+01 -1.876605e+01  3.067162e+01
+   endloop
+ endfacet
+ facet normal -1.282920e-01 -6.110571e-01  7.811212e-01
+   outer loop
+     vertex -4.749084e+01 -2.247016e+01  2.457277e+01
+     vertex -2.800000e+01 -1.876605e+01  3.067162e+01
+     vertex -4.749084e+01 -1.844113e+01  2.772461e+01
+   endloop
+ endfacet
+ facet normal -1.307297e-01 -6.108609e-01  7.808705e-01
+   outer loop
+     vertex -4.749084e+01 -2.247016e+01  2.457277e+01
+     vertex -4.749084e+01 -1.844113e+01  2.772461e+01
+     vertex -5.723626e+01 -1.820555e+01  2.627736e+01
+   endloop
+ endfacet
+ facet normal -1.388167e-01 -7.224579e-01  6.773363e-01
+   outer loop
+     vertex -4.749084e+01 -2.596888e+01  2.084098e+01
+     vertex -2.800000e+01 -2.528137e+01  2.556884e+01
+     vertex -4.749084e+01 -2.247016e+01  2.457277e+01
+   endloop
+ endfacet
+ facet normal -4.271914e-02  1.101643e-01 -9.929949e-01
+   outer loop
+     vertex -1.384481e+02  7.665216e+00 -1.942912e+01
+     vertex -1.449450e+02  4.657024e-05 -2.000000e+01
+     vertex -1.449450e+02  4.383690e+00 -1.951367e+01
+   endloop
+ endfacet
+ facet normal -1.538340e-01  3.285803e-01 -9.318638e-01
+   outer loop
+     vertex -1.384481e+02  7.665216e+00 -1.942912e+01
+     vertex -1.449450e+02  4.383690e+00 -1.951367e+01
+     vertex -1.449450e+02  8.825368e+00 -1.794751e+01
+   endloop
+ endfacet
+ facet normal -1.534927e-01  5.413691e-01 -8.266556e-01
+   outer loop
+     vertex -1.384481e+02  1.052478e+01 -1.804093e+01
+     vertex -1.449450e+02  8.825368e+00 -1.794751e+01
+     vertex -1.449450e+02  1.292412e+01 -1.526328e+01
+   endloop
+ endfacet
+ facet normal -1.261509e-01  4.332260e-01 -8.924131e-01
+   outer loop
+     vertex -1.384481e+02  1.052478e+01 -1.804093e+01
+     vertex -1.384481e+02  7.665216e+00 -1.942912e+01
+     vertex -1.449450e+02  8.825368e+00 -1.794751e+01
+   endloop
+ endfacet
+ facet normal -1.532547e-01  4.315558e-01 -8.889728e-01
+   outer loop
+     vertex -1.351996e+02  9.338614e+00 -1.917678e+01
+     vertex -1.384481e+02  7.665216e+00 -1.942912e+01
+     vertex -1.384481e+02  1.052478e+01 -1.804093e+01
+   endloop
+ endfacet
+ facet normal -7.673821e-02  7.334980e-01 -6.753458e-01
+   outer loop
+     vertex -1.351996e+02  1.139618e+01 -1.803013e+01
+     vertex -1.449450e+02  1.292412e+01 -1.526328e+01
+     vertex -1.449450e+02  1.627649e+01 -1.162224e+01
+   endloop
+ endfacet
+ facet normal -1.458689e-01  5.539376e-01 -8.196801e-01
+   outer loop
+     vertex -1.351996e+02  1.139618e+01 -1.803013e+01
+     vertex -1.384481e+02  1.052478e+01 -1.804093e+01
+     vertex -1.449450e+02  1.292412e+01 -1.526328e+01
+   endloop
+ endfacet
+ facet normal -1.415189e-01  6.719249e-01 -7.269727e-01
+   outer loop
+     vertex -1.351996e+02  1.139618e+01 -1.803013e+01
+     vertex -1.449450e+02  1.627649e+01 -1.162224e+01
+     vertex -1.254542e+02  1.783884e+01 -1.397245e+01
+   endloop
+ endfacet
+ facet normal -1.266511e-01  4.828759e-01 -8.664816e-01
+   outer loop
+     vertex -1.351996e+02  1.139618e+01 -1.803013e+01
+     vertex -1.351996e+02  9.338614e+00 -1.917678e+01
+     vertex -1.384481e+02  1.052478e+01 -1.804093e+01
+   endloop
+ endfacet
+ facet normal -8.618571e-02  1.464449e-01 -9.854572e-01
+   outer loop
+     vertex -1.303269e+02  9.409844e+00 -1.988011e+01
+     vertex -1.449450e+02  4.657024e-05 -2.000000e+01
+     vertex -1.384481e+02  7.665216e+00 -1.942912e+01
+   endloop
+ endfacet
+ facet normal -1.365784e-01  4.016810e-01 -9.055378e-01
+   outer loop
+     vertex -1.303269e+02  9.409844e+00 -1.988011e+01
+     vertex -1.384481e+02  7.665216e+00 -1.942912e+01
+     vertex -1.351996e+02  9.338614e+00 -1.917678e+01
+   endloop
+ endfacet
+ facet normal -1.320344e-01  4.825341e-01 -8.658682e-01
+   outer loop
+     vertex -1.303269e+02  9.409844e+00 -1.988011e+01
+     vertex -1.351996e+02  9.338614e+00 -1.917678e+01
+     vertex -1.351996e+02  1.139618e+01 -1.803013e+01
+   endloop
+ endfacet
+ facet normal -1.279656e-01  4.894587e-01 -8.625862e-01
+   outer loop
+     vertex -1.287027e+02  1.248621e+01 -1.837544e+01
+     vertex -1.303269e+02  9.409844e+00 -1.988011e+01
+     vertex -1.351996e+02  1.139618e+01 -1.803013e+01
+   endloop
+ endfacet
+ facet normal -1.410892e-01  6.785829e-01 -7.208461e-01
+   outer loop
+     vertex -1.287027e+02  1.248621e+01 -1.837544e+01
+     vertex -1.254542e+02  1.783884e+01 -1.397245e+01
+     vertex -1.157088e+02  1.855302e+01 -1.520759e+01
+   endloop
+ endfacet
+ facet normal -1.523670e-01  6.813658e-01 -7.159085e-01
+   outer loop
+     vertex -1.287027e+02  1.248621e+01 -1.837544e+01
+     vertex -1.351996e+02  1.139618e+01 -1.803013e+01
+     vertex -1.254542e+02  1.783884e+01 -1.397245e+01
+   endloop
+ endfacet
+ facet normal -8.646612e-02  6.003409e-01 -7.950562e-01
+   outer loop
+     vertex -1.157088e+02  9.547741e+00 -2.200741e+01
+     vertex -1.287027e+02  1.248621e+01 -1.837544e+01
+     vertex -1.157088e+02  1.855302e+01 -1.520759e+01
+   endloop
+ endfacet
+ facet normal -1.417328e-01  2.316552e-01 -9.624176e-01
+   outer loop
+     vertex -1.157088e+02  9.547741e+00 -2.200741e+01
+     vertex -8.647252e+01  9.431689e+00 -2.634089e+01
+     vertex -1.449450e+02  4.657024e-05 -2.000000e+01
+   endloop
+ endfacet
+ facet normal -1.421921e-01  2.331519e-01 -9.619884e-01
+   outer loop
+     vertex -1.157088e+02  9.547741e+00 -2.200741e+01
+     vertex -1.449450e+02  4.657024e-05 -2.000000e+01
+     vertex -1.303269e+02  9.409844e+00 -1.988011e+01
+   endloop
+ endfacet
+ facet normal -1.300450e-01  4.901987e-01 -8.618547e-01
+   outer loop
+     vertex -1.157088e+02  9.547741e+00 -2.200741e+01
+     vertex -1.303269e+02  9.409844e+00 -1.988011e+01
+     vertex -1.287027e+02  1.248621e+01 -1.837544e+01
+   endloop
+ endfacet
+ facet normal -7.184141e-02  9.585753e-01 -2.756306e-01
+   outer loop
+     vertex -1.319511e+02  2.177103e+01  2.940755e-01
+     vertex -1.449450e+02  1.859573e+01 -7.362030e+00
+     vertex -1.449450e+02  1.966603e+01 -3.639808e+00
+   endloop
+ endfacet
+ facet normal -1.324716e-01  9.870379e-01 -9.059519e-02
+   outer loop
+     vertex -1.319511e+02  2.177103e+01  2.940755e-01
+     vertex -1.449450e+02  1.966603e+01 -3.639808e+00
+     vertex -1.449450e+02  2.000002e+01 -9.187763e-04
+   endloop
+ endfacet
+ facet normal -1.366722e-01  9.845809e-01  1.091837e-01
+   outer loop
+     vertex -1.319511e+02  2.177103e+01  2.940755e-01
+     vertex -1.449450e+02  2.000002e+01 -9.187763e-04
+     vertex -1.449450e+02  1.951390e+01  4.382759e+00
+   endloop
+ endfacet
+ facet normal -5.909633e-02  9.414566e-01  3.319143e-01
+   outer loop
+     vertex -1.319511e+02  2.177103e+01  2.940755e-01
+     vertex -1.449450e+02  1.951390e+01  4.382759e+00
+     vertex -1.449450e+02  1.794793e+01  8.824549e+00
+   endloop
+ endfacet
+ facet normal -1.374042e-01  9.650393e-01  2.232022e-01
+   outer loop
+     vertex -1.319511e+02  2.177103e+01  2.940755e-01
+     vertex -1.449450e+02  1.794793e+01  8.824549e+00
+     vertex -1.254542e+02  2.056178e+01  9.521907e+00
+   endloop
+ endfacet
+ facet normal -1.292249e-01  9.742542e-01 -1.847424e-01
+   outer loop
+     vertex -1.319511e+02  2.177103e+01  2.940755e-01
+     vertex -1.254542e+02  2.093105e+01 -8.680147e+00
+     vertex -1.449450e+02  1.859573e+01 -7.362030e+00
+   endloop
+ endfacet
+ facet normal -1.786110e-01  5.929078e-01 -7.852123e-01
+   outer loop
+     vertex -1.010907e+02  1.497049e+01 -2.123789e+01
+     vertex -1.157088e+02  9.547741e+00 -2.200741e+01
+     vertex -1.157088e+02  1.855302e+01 -1.520759e+01
+   endloop
+ endfacet
+ facet normal -1.277250e-01  4.683693e-01 -8.742520e-01
+   outer loop
+     vertex -1.010907e+02  1.497049e+01 -2.123789e+01
+     vertex -8.647252e+01  9.431689e+00 -2.634089e+01
+     vertex -1.157088e+02  9.547741e+00 -2.200741e+01
+   endloop
+ endfacet
+ facet normal -1.434968e-01  4.386200e-01 -8.871421e-01
+   outer loop
+     vertex -1.010907e+02  1.497049e+01 -2.123789e+01
+     vertex -8.647252e+01  1.520412e+01 -2.348689e+01
+     vertex -8.647252e+01  9.431689e+00 -2.634089e+01
+   endloop
+ endfacet
+ facet normal -1.369782e-01  9.651654e-01  2.229188e-01
+   outer loop
+     vertex -1.254542e+02  2.265486e+01  4.595963e-01
+     vertex -1.319511e+02  2.177103e+01  2.940755e-01
+     vertex -1.254542e+02  2.056178e+01  9.521907e+00
+   endloop
+ endfacet
+ facet normal -1.279000e-01  9.746042e-01 -1.838159e-01
+   outer loop
+     vertex -1.254542e+02  2.265486e+01  4.595963e-01
+     vertex -1.254542e+02  2.093105e+01 -8.680147e+00
+     vertex -1.319511e+02  2.177103e+01  2.940755e-01
+   endloop
+ endfacet
+ facet normal -1.474625e-01  6.512724e-01 -7.443783e-01
+   outer loop
+     vertex -1.010907e+02  1.906114e+01 -1.765890e+01
+     vertex -1.010907e+02  1.497049e+01 -2.123789e+01
+     vertex -1.157088e+02  1.855302e+01 -1.520759e+01
+   endloop
+ endfacet
+ facet normal -1.342074e-01  9.655348e-01  2.230041e-01
+   outer loop
+     vertex -1.189573e+02  2.353988e+01  5.376825e-01
+     vertex -1.254542e+02  2.265486e+01  4.595963e-01
+     vertex -1.254542e+02  2.056178e+01  9.521907e+00
+   endloop
+ endfacet
+ facet normal -1.305085e-01  9.742702e-01 -1.837529e-01
+   outer loop
+     vertex -1.189573e+02  2.353988e+01  5.376825e-01
+     vertex -1.254542e+02  2.093105e+01 -8.680147e+00
+     vertex -1.254542e+02  2.265486e+01  4.595963e-01
+   endloop
+ endfacet
+ facet normal -7.721343e-02  9.617140e-01  2.629528e-01
+   outer loop
+     vertex -1.189573e+02  2.353988e+01  5.376825e-01
+     vertex -1.254542e+02  2.056178e+01  9.521907e+00
+     vertex -1.157088e+02  2.057506e+01  1.233500e+01
+   endloop
+ endfacet
+ facet normal -7.724113e-02  9.722713e-01 -2.207313e-01
+   outer loop
+     vertex -1.189573e+02  2.353988e+01  5.376825e-01
+     vertex -1.157088e+02  2.107359e+01 -1.146250e+01
+     vertex -1.254542e+02  2.093105e+01 -8.680147e+00
+   endloop
+ endfacet
+ facet normal -1.282216e-01  9.640260e-01 -2.328373e-01
+   outer loop
+     vertex -1.189573e+02  2.353988e+01  5.376825e-01
+     vertex -1.059634e+02  2.530915e+01  7.074209e-01
+     vertex -1.157088e+02  2.107359e+01 -1.146250e+01
+   endloop
+ endfacet
+ facet normal -1.157794e-01  7.978042e-01 -5.916956e-01
+   outer loop
+     vertex -1.027149e+02  2.274498e+01 -1.209798e+01
+     vertex -1.157088e+02  1.855302e+01 -1.520759e+01
+     vertex -1.157088e+02  1.993833e+01 -1.333972e+01
+   endloop
+ endfacet
+ facet normal -1.242374e-01  8.101179e-01 -5.729521e-01
+   outer loop
+     vertex -1.027149e+02  2.274498e+01 -1.209798e+01
+     vertex -1.010907e+02  1.906114e+01 -1.765890e+01
+     vertex -1.157088e+02  1.855302e+01 -1.520759e+01
+   endloop
+ endfacet
+ facet normal -1.341511e-01  8.479575e-01 -5.128076e-01
+   outer loop
+     vertex -1.027149e+02  2.274498e+01 -1.209798e+01
+     vertex -1.157088e+02  1.993833e+01 -1.333972e+01
+     vertex -1.157088e+02  2.107359e+01 -1.146250e+01
+   endloop
+ endfacet
+ facet normal -1.351675e-01  9.643757e-01 -2.273968e-01
+   outer loop
+     vertex -1.027149e+02  2.274498e+01 -1.209798e+01
+     vertex -1.157088e+02  2.107359e+01 -1.146250e+01
+     vertex -1.059634e+02  2.530915e+01  7.074209e-01
+   endloop
+ endfacet
+ facet normal -1.316685e-01  8.082715e-01 -5.738994e-01
+   outer loop
+     vertex -9.621794e+01  2.358578e+01 -1.240439e+01
+     vertex -1.010907e+02  1.906114e+01 -1.765890e+01
+     vertex -1.027149e+02  2.274498e+01 -1.209798e+01
+   endloop
+ endfacet
+ facet normal -1.363114e-01  9.142538e-01 -3.815223e-01
+   outer loop
+     vertex -9.296947e+01  2.581055e+01 -8.233750e+00
+     vertex -9.621794e+01  2.358578e+01 -1.240439e+01
+     vertex -1.027149e+02  2.274498e+01 -1.209798e+01
+   endloop
+ endfacet
+ facet normal -2.027725e-01  9.489877e-01 -2.414656e-01
+   outer loop
+     vertex -9.296947e+01  2.581055e+01 -8.233750e+00
+     vertex -1.027149e+02  2.274498e+01 -1.209798e+01
+     vertex -1.059634e+02  2.530915e+01  7.074209e-01
+   endloop
+ endfacet
+ facet normal -1.301059e-01  9.824051e-01 -1.339878e-01
+   outer loop
+     vertex -9.296947e+01  2.581055e+01 -8.233750e+00
+     vertex -1.059634e+02  2.530915e+01  7.074209e-01
+     vertex -8.647252e+01  2.795395e+01  1.173069e+00
+   endloop
+ endfacet
+ facet normal -2.505089e-01  9.203680e-01  3.002801e-01
+   outer loop
+     vertex -1.108361e+02  2.324900e+01  8.204337e+00
+     vertex -1.189573e+02  2.353988e+01  5.376825e-01
+     vertex -1.157088e+02  2.057506e+01  1.233500e+01
+   endloop
+ endfacet
+ facet normal -1.350210e-01  9.743570e-01  1.799938e-01
+   outer loop
+     vertex -1.108361e+02  2.324900e+01  8.204337e+00
+     vertex -1.059634e+02  2.530915e+01  7.074209e-01
+     vertex -1.189573e+02  2.353988e+01  5.376825e-01
+   endloop
+ endfacet
+ facet normal -6.610324e-02  6.758897e-01  7.340323e-01
+   outer loop
+     vertex -1.319511e+02  9.076363e+00  1.979100e+01
+     vertex -1.449450e+02  1.526383e+01  1.292347e+01
+     vertex -1.449450e+02  1.162285e+01  1.627605e+01
+   endloop
+ endfacet
+ facet normal -1.424039e-01  4.732911e-01  8.693196e-01
+   outer loop
+     vertex -1.319511e+02  9.076363e+00  1.979100e+01
+     vertex -1.449450e+02  1.162285e+01  1.627605e+01
+     vertex -1.449450e+02  7.362612e+00  1.859549e+01
+   endloop
+ endfacet
+ facet normal -1.239080e-01  2.742238e-01  9.536499e-01
+   outer loop
+     vertex -1.319511e+02  9.076363e+00  1.979100e+01
+     vertex -1.449450e+02  7.362612e+00  1.859549e+01
+     vertex -1.449450e+02  3.639617e+00  1.966605e+01
+   endloop
+ endfacet
+ facet normal -1.203091e-01  2.655557e-01  9.565594e-01
+   outer loop
+     vertex -1.319511e+02  9.076363e+00  1.979100e+01
+     vertex -1.449450e+02  3.639617e+00  1.966605e+01
+     vertex -1.254542e+02  2.008286e+00  2.257035e+01
+   endloop
+ endfacet
+ facet normal -1.420369e-01  5.866412e-01  7.972939e-01
+   outer loop
+     vertex -1.319511e+02  9.076363e+00  1.979100e+01
+     vertex -1.254542e+02  1.663268e+01  1.538856e+01
+     vertex -1.449450e+02  1.526383e+01  1.292347e+01
+   endloop
+ endfacet
+ facet normal -1.363390e-01  9.142577e-01 -3.815029e-01
+   outer loop
+     vertex -8.647252e+01  2.485323e+01 -1.284976e+01
+     vertex -9.621794e+01  2.358578e+01 -1.240439e+01
+     vertex -9.296947e+01  2.581055e+01 -8.233750e+00
+   endloop
+ endfacet
+ facet normal -1.267050e-01  4.396348e-01 -8.891946e-01
+   outer loop
+     vertex -7.185439e+01  1.701999e+01 -2.467209e+01
+     vertex -8.647252e+01  9.431689e+00 -2.634089e+01
+     vertex -8.647252e+01  1.520412e+01 -2.348689e+01
+   endloop
+ endfacet
+ facet normal -1.498292e-01  5.907397e-01  7.928290e-01
+   outer loop
+     vertex -1.254542e+02  9.988288e+00  2.033932e+01
+     vertex -1.254542e+02  1.663268e+01  1.538856e+01
+     vertex -1.319511e+02  9.076363e+00  1.979100e+01
+   endloop
+ endfacet
+ facet normal -1.182370e-01  2.673639e-01  9.563141e-01
+   outer loop
+     vertex -1.254542e+02  9.988288e+00  2.033932e+01
+     vertex -1.319511e+02  9.076363e+00  1.979100e+01
+     vertex -1.254542e+02  2.008286e+00  2.257035e+01
+   endloop
+ endfacet
+ facet normal -1.261978e-01  6.535262e-01 -7.463093e-01
+   outer loop
+     vertex -7.185439e+01  2.220990e+01 -2.012740e+01
+     vertex -5.723626e+01  2.430817e+01 -2.076186e+01
+     vertex -7.185439e+01  1.701999e+01 -2.467209e+01
+   endloop
+ endfacet
+ facet normal -1.849347e-01  5.871781e-01  7.880489e-01
+   outer loop
+     vertex -1.205815e+02  1.188718e+01  2.006795e+01
+     vertex -1.254542e+02  1.663268e+01  1.538856e+01
+     vertex -1.254542e+02  9.988288e+00  2.033932e+01
+   endloop
+ endfacet
+ facet normal -1.410041e-01  6.179278e-01  7.734876e-01
+   outer loop
+     vertex -1.205815e+02  1.188718e+01  2.006795e+01
+     vertex -1.157088e+02  1.724606e+01  1.667509e+01
+     vertex -1.254542e+02  1.663268e+01  1.538856e+01
+   endloop
+ endfacet
+ facet normal -2.039133e-01  2.635953e-01  9.428345e-01
+   outer loop
+     vertex -1.222057e+02  8.699941e+00  2.140208e+01
+     vertex -1.254542e+02  9.988288e+00  2.033932e+01
+     vertex -1.254542e+02  2.008286e+00  2.257035e+01
+   endloop
+ endfacet
+ facet normal -1.196591e-01  4.346211e-01  8.926288e-01
+   outer loop
+     vertex -1.222057e+02  8.699941e+00  2.140208e+01
+     vertex -1.205815e+02  1.188718e+01  2.006795e+01
+     vertex -1.254542e+02  9.988288e+00  2.033932e+01
+   endloop
+ endfacet
+ facet normal -1.654114e-01  2.469926e-01  9.547951e-01
+   outer loop
+     vertex -1.222057e+02  8.699941e+00  2.140208e+01
+     vertex -1.254542e+02  2.008286e+00  2.257035e+01
+     vertex -1.157088e+02  5.826065e+00  2.327106e+01
+   endloop
+ endfacet
+ facet normal -7.916394e-02  5.899136e-01 -8.035764e-01
+   outer loop
+     vertex -5.723626e+01  1.252499e+01 -2.941201e+01
+     vertex -7.185439e+01  1.701999e+01 -2.467209e+01
+     vertex -5.723626e+01  2.430817e+01 -2.076186e+01
+   endloop
+ endfacet
+ facet normal -1.409537e-01  4.638769e-01 -8.746143e-01
+   outer loop
+     vertex -5.723626e+01  1.252499e+01 -2.941201e+01
+     vertex -8.647252e+01  9.431689e+00 -2.634089e+01
+     vertex -7.185439e+01  1.701999e+01 -2.467209e+01
+   endloop
+ endfacet
+ facet normal -1.245344e-01  2.154330e-01 -9.685452e-01
+   outer loop
+     vertex -5.723626e+01  1.252499e+01 -2.941201e+01
+     vertex -2.800000e+01  2.050521e-05 -3.595710e+01
+     vertex -8.647252e+01  9.431689e+00 -2.634089e+01
+   endloop
+ endfacet
+ facet normal -1.349594e-01  9.822077e-01 -1.305906e-01
+   outer loop
+     vertex -7.997557e+01  2.754217e+01 -8.638297e+00
+     vertex -9.296947e+01  2.581055e+01 -8.233750e+00
+     vertex -8.647252e+01  2.795395e+01  1.173069e+00
+   endloop
+ endfacet
+ facet normal -1.347793e-01  9.163041e-01 -3.771223e-01
+   outer loop
+     vertex -7.997557e+01  2.754217e+01 -8.638297e+00
+     vertex -7.672710e+01  2.603878e+01 -1.345209e+01
+     vertex -8.647252e+01  2.485323e+01 -1.284976e+01
+   endloop
+ endfacet
+ facet normal -1.338416e-01  9.159408e-01 -3.783370e-01
+   outer loop
+     vertex -7.997557e+01  2.754217e+01 -8.638297e+00
+     vertex -8.647252e+01  2.485323e+01 -1.284976e+01
+     vertex -9.296947e+01  2.581055e+01 -8.233750e+00
+   endloop
+ endfacet
+ facet normal -1.330491e-01  9.826333e-01 -1.293435e-01
+   outer loop
+     vertex -7.997557e+01  2.754217e+01 -8.638297e+00
+     vertex -8.647252e+01  2.795395e+01  1.173069e+00
+     vertex -6.698168e+01  3.061029e+01  1.304296e+00
+   endloop
+ endfacet
+ facet normal -1.270695e-01  6.104950e-01  7.817603e-01
+   outer loop
+     vertex -1.157088e+02  1.199823e+01  2.077325e+01
+     vertex -1.157088e+02  1.724606e+01  1.667509e+01
+     vertex -1.205815e+02  1.188718e+01  2.006795e+01
+   endloop
+ endfacet
+ facet normal -1.383782e-01  4.415879e-01  8.864827e-01
+   outer loop
+     vertex -1.157088e+02  1.199823e+01  2.077325e+01
+     vertex -1.205815e+02  1.188718e+01  2.006795e+01
+     vertex -1.222057e+02  8.699941e+00  2.140208e+01
+   endloop
+ endfacet
+ facet normal -1.002168e-01  3.732469e-01  9.223033e-01
+   outer loop
+     vertex -1.157088e+02  1.199823e+01  2.077325e+01
+     vertex -1.222057e+02  8.699941e+00  2.140208e+01
+     vertex -1.157088e+02  5.826065e+00  2.327106e+01
+   endloop
+ endfacet
+ facet normal -1.236457e-01  7.528279e-01  6.464997e-01
+   outer loop
+     vertex -1.027149e+02  2.146094e+01  1.425214e+01
+     vertex -1.157088e+02  1.908949e+01  1.452848e+01
+     vertex -1.157088e+02  1.724606e+01  1.667509e+01
+   endloop
+ endfacet
+ facet normal -1.378554e-01  8.200720e-01  5.554077e-01
+   outer loop
+     vertex -1.027149e+02  2.146094e+01  1.425214e+01
+     vertex -1.157088e+02  2.057506e+01  1.233500e+01
+     vertex -1.157088e+02  1.908949e+01  1.452848e+01
+   endloop
+ endfacet
+ facet normal -1.245718e-01  8.934967e-01  4.314459e-01
+   outer loop
+     vertex -1.027149e+02  2.146094e+01  1.425214e+01
+     vertex -1.108361e+02  2.324900e+01  8.204337e+00
+     vertex -1.157088e+02  2.057506e+01  1.233500e+01
+   endloop
+ endfacet
+ facet normal -1.645998e-01  7.856975e-01 -5.963106e-01
+   outer loop
+     vertex -7.023015e+01  2.682937e+01 -1.385322e+01
+     vertex -5.723626e+01  2.653591e+01 -1.782660e+01
+     vertex -5.723626e+01  2.430817e+01 -2.076186e+01
+   endloop
+ endfacet
+ facet normal -1.413187e-01  8.143094e-01 -5.629646e-01
+   outer loop
+     vertex -7.023015e+01  2.682937e+01 -1.385322e+01
+     vertex -5.723626e+01  2.430817e+01 -2.076186e+01
+     vertex -7.185439e+01  2.220990e+01 -2.012740e+01
+   endloop
+ endfacet
+ facet normal -1.339575e-01  8.142595e-01 -5.648335e-01
+   outer loop
+     vertex -7.023015e+01  2.682937e+01 -1.385322e+01
+     vertex -7.185439e+01  2.220990e+01 -2.012740e+01
+     vertex -7.672710e+01  2.603878e+01 -1.345209e+01
+   endloop
+ endfacet
+ facet normal -1.349204e-01  8.529702e-01 -5.042204e-01
+   outer loop
+     vertex -7.023015e+01  2.682937e+01 -1.385322e+01
+     vertex -5.723626e+01  2.841106e+01 -1.465447e+01
+     vertex -5.723626e+01  2.653591e+01 -1.782660e+01
+   endloop
+ endfacet
+ facet normal -1.364046e-01  9.688057e-01  2.069041e-01
+   outer loop
+     vertex -9.296947e+01  2.512561e+01  1.013325e+01
+     vertex -8.647252e+01  2.795395e+01  1.173069e+00
+     vertex -1.059634e+02  2.530915e+01  7.074209e-01
+   endloop
+ endfacet
+ facet normal -1.206016e-01  2.238726e-01 -9.671279e-01
+   outer loop
+     vertex -4.261813e+01  1.421846e+01 -3.084290e+01
+     vertex -2.800000e+01  2.050521e-05 -3.595710e+01
+     vertex -5.723626e+01  1.252499e+01 -2.941201e+01
+   endloop
+ endfacet
+ facet normal -2.167083e-01  1.123440e-01 -9.697507e-01
+   outer loop
+     vertex -3.774542e+01  1.235577e+01 -3.234792e+01
+     vertex -2.800000e+01  8.220769e+00 -3.500474e+01
+     vertex -2.800000e+01  2.050521e-05 -3.595710e+01
+   endloop
+ endfacet
+ facet normal -1.118627e-01  3.370095e-01 -9.348322e-01
+   outer loop
+     vertex -3.774542e+01  1.235577e+01 -3.234792e+01
+     vertex -2.800000e+01  1.600606e+01 -3.219812e+01
+     vertex -2.800000e+01  8.220769e+00 -3.500474e+01
+   endloop
+ endfacet
+ facet normal -2.711032e-01  6.666238e-02 -9.602391e-01
+   outer loop
+     vertex -3.774542e+01  1.235577e+01 -3.234792e+01
+     vertex -2.800000e+01  2.050521e-05 -3.595710e+01
+     vertex -4.261813e+01  1.421846e+01 -3.084290e+01
+   endloop
+ endfacet
+ facet normal -1.330165e-01  8.836725e-01  4.488090e-01
+   outer loop
+     vertex -8.647252e+01  2.368928e+01  1.488681e+01
+     vertex -9.296947e+01  2.512561e+01  1.013325e+01
+     vertex -9.621794e+01  2.266206e+01  1.402103e+01
+   endloop
+ endfacet
+ facet normal -1.394891e-01  4.656992e-01 -8.738804e-01
+   outer loop
+     vertex -4.261813e+01  1.767333e+01 -2.900176e+01
+     vertex -4.261813e+01  1.421846e+01 -3.084290e+01
+     vertex -5.723626e+01  1.252499e+01 -2.941201e+01
+   endloop
+ endfacet
+ facet normal -1.333785e-01  9.682051e-01  2.116341e-01
+   outer loop
+     vertex -7.997557e+01  2.671692e+01  1.092692e+01
+     vertex -6.698168e+01  3.061029e+01  1.304296e+00
+     vertex -8.647252e+01  2.795395e+01  1.173069e+00
+   endloop
+ endfacet
+ facet normal -1.314898e-01  9.687232e-01  2.104418e-01
+   outer loop
+     vertex -7.997557e+01  2.671692e+01  1.092692e+01
+     vertex -8.647252e+01  2.795395e+01  1.173069e+00
+     vertex -9.296947e+01  2.512561e+01  1.013325e+01
+   endloop
+ endfacet
+ facet normal -1.355816e-01  8.817849e-01  4.517444e-01
+   outer loop
+     vertex -7.997557e+01  2.671692e+01  1.092692e+01
+     vertex -9.296947e+01  2.512561e+01  1.013325e+01
+     vertex -8.647252e+01  2.368928e+01  1.488681e+01
+   endloop
+ endfacet
+ facet normal -1.342089e-01  9.320281e-01 -3.366178e-01
+   outer loop
+     vertex -6.210897e+01  3.057009e+01 -6.733819e+00
+     vertex -5.723626e+01  2.841106e+01 -1.465447e+01
+     vertex -7.023015e+01  2.682937e+01 -1.385322e+01
+   endloop
+ endfacet
+ facet normal -1.171064e-01  5.414817e-01 -8.325165e-01
+   outer loop
+     vertex -3.774542e+01  1.716478e+01 -3.007363e+01
+     vertex -2.800000e+01  2.294349e+01 -2.768591e+01
+     vertex -2.800000e+01  1.600606e+01 -3.219812e+01
+   endloop
+ endfacet
+ facet normal -1.447009e-01  4.230243e-01 -8.944898e-01
+   outer loop
+     vertex -3.774542e+01  1.716478e+01 -3.007363e+01
+     vertex -2.800000e+01  1.600606e+01 -3.219812e+01
+     vertex -3.774542e+01  1.235577e+01 -3.234792e+01
+   endloop
+ endfacet
+ facet normal -1.150194e-01  4.246864e-01 -8.980044e-01
+   outer loop
+     vertex -3.774542e+01  1.716478e+01 -3.007363e+01
+     vertex -3.774542e+01  1.235577e+01 -3.234792e+01
+     vertex -4.261813e+01  1.421846e+01 -3.084290e+01
+   endloop
+ endfacet
+ facet normal -1.435426e-01  4.654267e-01 -8.733691e-01
+   outer loop
+     vertex -3.774542e+01  1.716478e+01 -3.007363e+01
+     vertex -4.261813e+01  1.421846e+01 -3.084290e+01
+     vertex -4.261813e+01  1.767333e+01 -2.900176e+01
+   endloop
+ endfacet
+ facet normal -1.683400e-01  5.833256e-01 -7.946023e-01
+   outer loop
+     vertex -4.424237e+01  2.390875e+01 -2.380789e+01
+     vertex -5.723626e+01  1.252499e+01 -2.941201e+01
+     vertex -5.723626e+01  2.430817e+01 -2.076186e+01
+   endloop
+ endfacet
+ facet normal -1.890953e-01  5.989227e-01 -7.781611e-01
+   outer loop
+     vertex -4.424237e+01  2.390875e+01 -2.380789e+01
+     vertex -4.261813e+01  1.767333e+01 -2.900176e+01
+     vertex -5.723626e+01  1.252499e+01 -2.941201e+01
+   endloop
+ endfacet
+ facet normal -1.169029e-01  7.897083e-01 -6.022412e-01
+   outer loop
+     vertex -4.424237e+01  2.390875e+01 -2.380789e+01
+     vertex -5.723626e+01  2.430817e+01 -2.076186e+01
+     vertex -4.749084e+01  2.867004e+01 -1.693393e+01
+   endloop
+ endfacet
+ facet normal -1.195353e-01  1.867400e-01  9.751100e-01
+   outer loop
+     vertex -1.059634e+02  1.651978e+00  2.526508e+01
+     vertex -1.157088e+02  5.826065e+00  2.327106e+01
+     vertex -1.157088e+02  3.183957e+00  2.377704e+01
+   endloop
+ endfacet
+ facet normal -1.387870e-01  7.619800e-02  9.873865e-01
+   outer loop
+     vertex -1.059634e+02  1.651978e+00  2.526508e+01
+     vertex -1.157088e+02  3.183957e+00  2.377704e+01
+     vertex -1.157088e+02  5.018317e-01  2.398403e+01
+   endloop
+ endfacet
+ facet normal -1.262030e-01 -3.488924e-02  9.913907e-01
+   outer loop
+     vertex -1.059634e+02  1.651978e+00  2.526508e+01
+     vertex -1.157088e+02  5.018317e-01  2.398403e+01
+     vertex -1.157088e+02 -2.186604e+00  2.388941e+01
+   endloop
+ endfacet
+ facet normal -1.615497e-01  1.685417e-01  9.723659e-01
+   outer loop
+     vertex -1.010907e+02  3.717894e+00  2.571655e+01
+     vertex -1.010907e+02  5.153942e+00  2.546764e+01
+     vertex -1.059634e+02  1.651978e+00  2.526508e+01
+   endloop
+ endfacet
+ facet normal -1.346214e-01  8.813100e-01  4.529567e-01
+   outer loop
+     vertex -7.672710e+01  2.481016e+01  1.560234e+01
+     vertex -7.997557e+01  2.671692e+01  1.092692e+01
+     vertex -8.647252e+01  2.368928e+01  1.488681e+01
+   endloop
+ endfacet
+ facet normal -1.538526e-01 -9.326335e-01  3.263803e-01
+   outer loop
+     vertex -1.384481e+02 -1.976750e+01  6.744782e+00
+     vertex -1.449450e+02 -1.801909e+01  8.678266e+00
+     vertex -1.449450e+02 -1.949838e+01  4.451186e+00
+   endloop
+ endfacet
+ facet normal -1.146449e-01  5.884458e-01 -8.003675e-01
+   outer loop
+     vertex -3.774542e+01  2.358579e+01 -2.535278e+01
+     vertex -3.774542e+01  1.716478e+01 -3.007363e+01
+     vertex -4.261813e+01  1.767333e+01 -2.900176e+01
+   endloop
+ endfacet
+ facet normal -9.955117e-02  7.965686e-01 -5.962953e-01
+   outer loop
+     vertex -3.774542e+01  2.358579e+01 -2.535278e+01
+     vertex -4.749084e+01  2.867004e+01 -1.693393e+01
+     vertex -2.800000e+01  3.286914e+01 -1.457849e+01
+   endloop
+ endfacet
+ facet normal -1.171067e-01  7.174761e-01 -6.866688e-01
+   outer loop
+     vertex -3.774542e+01  2.358579e+01 -2.535278e+01
+     vertex -2.800000e+01  2.866555e+01 -2.170713e+01
+     vertex -2.800000e+01  2.294349e+01 -2.768591e+01
+   endloop
+ endfacet
+ facet normal -2.507100e-01  8.338803e-01 -4.917196e-01
+   outer loop
+     vertex -3.774542e+01  2.358579e+01 -2.535278e+01
+     vertex -2.800000e+01  3.286914e+01 -1.457849e+01
+     vertex -2.800000e+01  2.866555e+01 -2.170713e+01
+   endloop
+ endfacet
+ facet normal -1.520567e-01  5.854634e-01 -7.963111e-01
+   outer loop
+     vertex -3.774542e+01  2.358579e+01 -2.535278e+01
+     vertex -2.800000e+01  2.294349e+01 -2.768591e+01
+     vertex -3.774542e+01  1.716478e+01 -3.007363e+01
+   endloop
+ endfacet
+ facet normal -1.029000e-01  7.942721e-01 -5.987850e-01
+   outer loop
+     vertex -3.774542e+01  2.358579e+01 -2.535278e+01
+     vertex -4.424237e+01  2.390875e+01 -2.380789e+01
+     vertex -4.749084e+01  2.867004e+01 -1.693393e+01
+   endloop
+ endfacet
+ facet normal -1.548987e-01  6.081591e-01 -7.785557e-01
+   outer loop
+     vertex -3.774542e+01  2.358579e+01 -2.535278e+01
+     vertex -4.261813e+01  1.767333e+01 -2.900176e+01
+     vertex -4.424237e+01  2.390875e+01 -2.380789e+01
+   endloop
+ endfacet
+ facet normal -1.132508e-01 -8.412611e-01  5.286340e-01
+   outer loop
+     vertex -1.351996e+02 -1.980020e+01  7.931622e+00
+     vertex -1.449450e+02 -1.563630e+01  1.247021e+01
+     vertex -1.449450e+02 -1.801909e+01  8.678266e+00
+   endloop
+ endfacet
+ facet normal -1.178037e-01 -8.447404e-01  5.220498e-01
+   outer loop
+     vertex -1.351996e+02 -1.980020e+01  7.931622e+00
+     vertex -1.254542e+02 -1.639365e+01  1.564295e+01
+     vertex -1.449450e+02 -1.563630e+01  1.247021e+01
+   endloop
+ endfacet
+ facet normal -1.409253e-01 -9.221241e-01  3.603155e-01
+   outer loop
+     vertex -1.351996e+02 -1.980020e+01  7.931622e+00
+     vertex -1.449450e+02 -1.801909e+01  8.678266e+00
+     vertex -1.384481e+02 -1.976750e+01  6.744782e+00
+   endloop
+ endfacet
+ facet normal -1.469827e-01 -9.829148e-01  1.107904e-01
+   outer loop
+     vertex -1.384481e+02 -2.055197e+01  3.723265e+00
+     vertex -1.449450e+02 -1.949838e+01  4.451186e+00
+     vertex -1.449450e+02 -2.000000e+01  9.180886e-04
+   endloop
+ endfacet
+ facet normal -1.277517e-01 -9.599794e-01  2.492371e-01
+   outer loop
+     vertex -1.384481e+02 -2.055197e+01  3.723265e+00
+     vertex -1.384481e+02 -1.976750e+01  6.744782e+00
+     vertex -1.449450e+02 -1.949838e+01  4.451186e+00
+   endloop
+ endfacet
+ facet normal -1.251761e-01 -9.402264e-01  3.167100e-01
+   outer loop
+     vertex -1.351996e+02 -2.056378e+01  5.664760e+00
+     vertex -1.351996e+02 -1.980020e+01  7.931622e+00
+     vertex -1.384481e+02 -1.976750e+01  6.744782e+00
+   endloop
+ endfacet
+ facet normal -1.519260e-01 -9.566746e-01  2.483791e-01
+   outer loop
+     vertex -1.351996e+02 -2.056378e+01  5.664760e+00
+     vertex -1.384481e+02 -1.976750e+01  6.744782e+00
+     vertex -1.384481e+02 -2.055197e+01  3.723265e+00
+   endloop
+ endfacet
+ facet normal -1.350323e-01  8.066041e-01  5.754617e-01
+   outer loop
+     vertex -7.023015e+01  2.555715e+01  1.607976e+01
+     vertex -5.723626e+01  2.491040e+01  2.003531e+01
+     vertex -5.723626e+01  2.705053e+01  1.703557e+01
+   endloop
+ endfacet
+ facet normal -1.649295e-01  7.316577e-01  6.614191e-01
+   outer loop
+     vertex -7.023015e+01  2.555715e+01  1.607976e+01
+     vertex -5.723626e+01  2.243929e+01  2.276884e+01
+     vertex -5.723626e+01  2.491040e+01  2.003531e+01
+   endloop
+ endfacet
+ facet normal -1.339520e-01  8.999111e-01  4.149903e-01
+   outer loop
+     vertex -6.210897e+01  2.988347e+01  9.319483e+00
+     vertex -7.023015e+01  2.555715e+01  1.607976e+01
+     vertex -5.723626e+01  2.705053e+01  1.703557e+01
+   endloop
+ endfacet
+ facet normal -1.342124e-01  9.762411e-01  1.701187e-01
+   outer loop
+     vertex -5.398779e+01  3.238110e+01  1.393683e+00
+     vertex -6.698168e+01  3.061029e+01  1.304296e+00
+     vertex -6.210897e+01  2.988347e+01  9.319483e+00
+   endloop
+ endfacet
+ facet normal -1.339482e-01  9.872377e-01 -8.613763e-02
+   outer loop
+     vertex -5.398779e+01  3.238110e+01  1.393683e+00
+     vertex -6.210897e+01  3.057009e+01 -6.733819e+00
+     vertex -6.698168e+01  3.061029e+01  1.304296e+00
+   endloop
+ endfacet
+ facet normal -1.286455e-01 -9.693416e-01  2.093496e-01
+   outer loop
+     vertex -1.351996e+02 -2.106874e+01  3.326655e+00
+     vertex -1.351996e+02 -2.056378e+01  5.664760e+00
+     vertex -1.384481e+02 -2.055197e+01  3.723265e+00
+   endloop
+ endfacet
+ facet normal -1.427349e-01 -9.843702e-01  1.031607e-01
+   outer loop
+     vertex -1.384481e+02 -2.087735e+01  6.184713e-01
+     vertex -1.384481e+02 -2.055197e+01  3.723265e+00
+     vertex -1.449450e+02 -2.000000e+01  9.180886e-04
+   endloop
+ endfacet
+ facet normal -1.226205e-01 -9.862180e-01 -1.110777e-01
+   outer loop
+     vertex -1.384481e+02 -2.087735e+01  6.184713e-01
+     vertex -1.449450e+02 -2.000000e+01  9.180886e-04
+     vertex -1.449450e+02 -1.949873e+01 -4.449658e+00
+   endloop
+ endfacet
+ facet normal -1.439749e-01 -9.841915e-01  1.031419e-01
+   outer loop
+     vertex -1.384481e+02 -2.087735e+01  6.184713e-01
+     vertex -1.351996e+02 -2.106874e+01  3.326655e+00
+     vertex -1.384481e+02 -2.055197e+01  3.723265e+00
+   endloop
+ endfacet
+ facet normal -1.235372e-01 -3.604797e-01  9.245501e-01
+   outer loop
+     vertex -1.059634e+02 -1.174158e+01  2.243187e+01
+     vertex -1.157088e+02 -7.447527e+00  2.280394e+01
+     vertex -1.157088e+02 -9.953858e+00  2.182673e+01
+   endloop
+ endfacet
+ facet normal -1.389566e-01 -4.607768e-01  8.765705e-01
+   outer loop
+     vertex -1.059634e+02 -1.174158e+01  2.243187e+01
+     vertex -1.157088e+02 -9.953858e+00  2.182673e+01
+     vertex -1.157088e+02 -1.233500e+01  2.057506e+01
+   endloop
+ endfacet
+ facet normal -1.342034e-01  7.634377e-01  6.317850e-01
+   outer loop
+     vertex -7.185439e+01  2.042433e+01  2.193715e+01
+     vertex -7.023015e+01  2.555715e+01  1.607976e+01
+     vertex -7.672710e+01  2.481016e+01  1.560234e+01
+   endloop
+ endfacet
+ facet normal -1.411048e-01  7.636333e-01  6.300426e-01
+   outer loop
+     vertex -7.185439e+01  2.042433e+01  2.193715e+01
+     vertex -5.723626e+01  2.243929e+01  2.276884e+01
+     vertex -7.023015e+01  2.555715e+01  1.607976e+01
+   endloop
+ endfacet
+ facet normal -1.339297e-01 -4.920737e-01  8.601897e-01
+   outer loop
+     vertex -1.059634e+02 -1.338503e+01  2.149173e+01
+     vertex -1.059634e+02 -1.174158e+01  2.243187e+01
+     vertex -1.157088e+02 -1.233500e+01  2.057506e+01
+   endloop
+ endfacet
+ facet normal -1.332730e-01 -4.921177e-01  8.602665e-01
+   outer loop
+     vertex -1.010907e+02 -1.392299e+01  2.193887e+01
+     vertex -1.059634e+02 -1.174158e+01  2.243187e+01
+     vertex -1.059634e+02 -1.338503e+01  2.149173e+01
+   endloop
+ endfacet
+ facet normal -1.292660e-01 -9.692627e-01  2.093326e-01
+   outer loop
+     vertex -1.189573e+02 -2.235937e+01  7.380634e+00
+     vertex -1.351996e+02 -2.056378e+01  5.664760e+00
+     vertex -1.351996e+02 -2.106874e+01  3.326655e+00
+   endloop
+ endfacet
+ facet normal -1.156959e-01 -8.462595e-01  5.200570e-01
+   outer loop
+     vertex -1.189573e+02 -2.235937e+01  7.380634e+00
+     vertex -1.254542e+02 -1.639365e+01  1.564295e+01
+     vertex -1.351996e+02 -1.980020e+01  7.931622e+00
+   endloop
+ endfacet
+ facet normal -1.371796e-01 -9.387212e-01  3.162030e-01
+   outer loop
+     vertex -1.189573e+02 -2.235937e+01  7.380634e+00
+     vertex -1.351996e+02 -1.980020e+01  7.931622e+00
+     vertex -1.351996e+02 -2.056378e+01  5.664760e+00
+   endloop
+ endfacet
+ facet normal -1.365273e-01 -5.540628e-01  8.212032e-01
+   outer loop
+     vertex -1.010907e+02 -1.513118e+01  2.112371e+01
+     vertex -1.010907e+02 -1.392299e+01  2.193887e+01
+     vertex -1.059634e+02 -1.338503e+01  2.149173e+01
+   endloop
+ endfacet
+ facet normal -1.324688e-01  9.592077e-01  2.497452e-01
+   outer loop
+     vertex -4.099389e+01  3.415184e+01  1.484591e+00
+     vertex -4.749084e+01  3.326648e+01  1.438947e+00
+     vertex -4.749084e+01  2.974425e+01  1.496691e+01
+   endloop
+ endfacet
+ facet normal -1.782282e-01  9.574213e-01  2.271104e-01
+   outer loop
+     vertex -4.099389e+01  3.415184e+01  1.484591e+00
+     vertex -4.749084e+01  2.974425e+01  1.496691e+01
+     vertex -2.800000e+01  3.461052e+01  9.748097e+00
+   endloop
+ endfacet
+ facet normal -1.341885e-01  9.884266e-01 -7.075487e-02
+   outer loop
+     vertex -4.099389e+01  3.415184e+01  1.484591e+00
+     vertex -2.800000e+01  3.592250e+01  1.577020e+00
+     vertex -2.800000e+01  3.533161e+01 -6.677595e+00
+   endloop
+ endfacet
+ facet normal -1.344415e-01  9.783899e-01  1.570944e-01
+   outer loop
+     vertex -4.099389e+01  3.415184e+01  1.484591e+00
+     vertex -2.800000e+01  3.461052e+01  9.748097e+00
+     vertex -2.800000e+01  3.592250e+01  1.577020e+00
+   endloop
+ endfacet
+ facet normal -1.320069e-01  9.772509e-01 -1.659963e-01
+   outer loop
+     vertex -4.099389e+01  3.415184e+01  1.484591e+00
+     vertex -4.749084e+01  3.092553e+01 -1.234263e+01
+     vertex -4.749084e+01  3.326648e+01  1.438947e+00
+   endloop
+ endfacet
+ facet normal -1.784066e-01  9.734644e-01 -1.433111e-01
+   outer loop
+     vertex -4.099389e+01  3.415184e+01  1.484591e+00
+     vertex -2.800000e+01  3.533161e+01 -6.677595e+00
+     vertex -4.749084e+01  3.092553e+01 -1.234263e+01
+   endloop
+ endfacet
+ facet normal -1.547388e-01 -5.976134e-01  7.867109e-01
+   outer loop
+     vertex -1.010907e+02 -1.629175e+01  2.024210e+01
+     vertex -1.010907e+02 -1.513118e+01  2.112371e+01
+     vertex -1.059634e+02 -1.338503e+01  2.149173e+01
+   endloop
+ endfacet
+ facet normal -9.300361e-02 -9.940815e-01  5.614514e-02
+   outer loop
+     vertex -1.254542e+02 -2.237171e+01 -3.600019e+00
+     vertex -1.189573e+02 -2.235937e+01  7.380634e+00
+     vertex -1.351996e+02 -2.106874e+01  3.326655e+00
+   endloop
+ endfacet
+ facet normal -9.868543e-02 -9.939542e-01  4.812720e-02
+   outer loop
+     vertex -1.254542e+02 -2.237171e+01 -3.600019e+00
+     vertex -1.351996e+02 -2.106874e+01  3.326655e+00
+     vertex -1.384481e+02 -2.087735e+01  6.184713e-01
+   endloop
+ endfacet
+ facet normal -2.331422e-01 -9.624534e-01  1.390257e-01
+   outer loop
+     vertex -1.157088e+02 -2.387590e+01  2.329518e+00
+     vertex -1.189573e+02 -2.235937e+01  7.380634e+00
+     vertex -1.254542e+02 -2.237171e+01 -3.600019e+00
+   endloop
+ endfacet
+ facet normal -1.840512e-01 -9.560485e-01 -2.282464e-01
+   outer loop
+     vertex -1.254542e+02 -2.158525e+01 -6.894239e+00
+     vertex -1.254542e+02 -2.237171e+01 -3.600019e+00
+     vertex -1.384481e+02 -2.087735e+01  6.184713e-01
+   endloop
+ endfacet
+ facet normal -1.410412e-01 -9.344596e-01 -3.269443e-01
+   outer loop
+     vertex -1.254542e+02 -2.158525e+01 -6.894239e+00
+     vertex -1.449450e+02 -1.949873e+01 -4.449658e+00
+     vertex -1.449450e+02 -1.801966e+01 -8.677096e+00
+   endloop
+ endfacet
+ facet normal -1.199313e-01 -9.861563e-01 -1.145083e-01
+   outer loop
+     vertex -1.254542e+02 -2.158525e+01 -6.894239e+00
+     vertex -1.384481e+02 -2.087735e+01  6.184713e-01
+     vertex -1.449450e+02 -1.949873e+01 -4.449658e+00
+   endloop
+ endfacet
+ facet normal -1.764407e-01 -9.834777e-01  4.050116e-02
+   outer loop
+     vertex -1.157088e+02 -2.398660e+01 -3.584649e-01
+     vertex -1.157088e+02 -2.387590e+01  2.329518e+00
+     vertex -1.254542e+02 -2.237171e+01 -3.600019e+00
+   endloop
+ endfacet
+ facet normal -7.336857e-02  6.853433e-01  7.245147e-01
+   outer loop
+     vertex -5.398779e+01  1.944553e+01  2.592970e+01
+     vertex -4.749084e+01  2.710073e+01  1.934630e+01
+     vertex -5.723626e+01  2.243929e+01  2.276884e+01
+   endloop
+ endfacet
+ facet normal -2.316134e-01  5.762186e-01  7.837904e-01
+   outer loop
+     vertex -5.723626e+01  1.503854e+01  2.820965e+01
+     vertex -5.398779e+01  1.944553e+01  2.592970e+01
+     vertex -5.723626e+01  2.243929e+01  2.276884e+01
+   endloop
+ endfacet
+ facet normal -1.264621e-01  5.875697e-01  7.992304e-01
+   outer loop
+     vertex -5.723626e+01  1.503854e+01  2.820965e+01
+     vertex -5.723626e+01  2.243929e+01  2.276884e+01
+     vertex -7.185439e+01  2.042433e+01  2.193715e+01
+   endloop
+ endfacet
+ facet normal -1.890523e-01  3.326599e-01  9.239029e-01
+   outer loop
+     vertex -6.698168e+01  3.229799e+00  3.046735e+01
+     vertex -5.723626e+01  6.396176e+00  3.132141e+01
+     vertex -5.723626e+01  1.503854e+01  2.820965e+01
+   endloop
+ endfacet
+ facet normal -1.321173e-01  1.420238e-01  9.810068e-01
+   outer loop
+     vertex -6.698168e+01  3.229799e+00  3.046735e+01
+     vertex -5.723626e+01  2.749280e+00  3.184938e+01
+     vertex -5.723626e+01  6.396176e+00  3.132141e+01
+   endloop
+ endfacet
+ facet normal -1.092444e-01  1.992990e-01  9.738304e-01
+   outer loop
+     vertex -6.698168e+01  3.229799e+00  3.046735e+01
+     vertex -7.185439e+01  6.853659e+00  2.917909e+01
+     vertex -7.185439e+01  5.160536e+00  2.952560e+01
+   endloop
+ endfacet
+ facet normal -1.331303e-01  1.424222e-01  9.808120e-01
+   outer loop
+     vertex -6.698168e+01  3.229799e+00  3.046735e+01
+     vertex -7.185439e+01  5.160536e+00  2.952560e+01
+     vertex -7.185439e+01  3.450257e+00  2.977394e+01
+   endloop
+ endfacet
+ facet normal -1.341298e-01 -9.188114e-01 -3.712073e-01
+   outer loop
+     vertex -1.254542e+02 -2.031658e+01 -1.003444e+01
+     vertex -1.254542e+02 -2.158525e+01 -6.894239e+00
+     vertex -1.449450e+02 -1.801966e+01 -8.677096e+00
+   endloop
+ endfacet
+ facet normal -1.402767e-01 -9.876147e-01 -7.028323e-02
+   outer loop
+     vertex -1.157088e+02 -2.379563e+01 -3.041940e+00
+     vertex -1.157088e+02 -2.398660e+01 -3.584649e-01
+     vertex -1.254542e+02 -2.237171e+01 -3.600019e+00
+   endloop
+ endfacet
+ facet normal -2.671659e-04  6.521654e-01  7.580767e-01
+   outer loop
+     vertex -5.236355e+01  1.777782e+01  2.736499e+01
+     vertex -4.749084e+01  2.710073e+01  1.934630e+01
+     vertex -5.398779e+01  1.944553e+01  2.592970e+01
+   endloop
+ endfacet
+ facet normal -1.647606e-01  5.463051e-01  8.212215e-01
+   outer loop
+     vertex -5.236355e+01  1.777782e+01  2.736499e+01
+     vertex -5.398779e+01  1.944553e+01  2.592970e+01
+     vertex -5.723626e+01  1.503854e+01  2.820965e+01
+   endloop
+ endfacet
+ facet normal -1.878210e-01 -3.084431e-02  9.817189e-01
+   outer loop
+     vertex -6.698168e+01  8.799611e-01  3.062543e+01
+     vertex -7.185439e+01  3.450257e+00  2.977394e+01
+     vertex -7.672710e+01 -6.746083e+00  2.852135e+01
+   endloop
+ endfacet
+ facet normal -1.502604e-01 -8.579773e-02  9.849165e-01
+   outer loop
+     vertex -6.698168e+01  8.799611e-01  3.062543e+01
+     vertex -5.723626e+01 -4.605160e+00  3.163439e+01
+     vertex -5.723626e+01 -9.341460e-01  3.195417e+01
+   endloop
+ endfacet
+ facet normal -1.298873e-01  2.819639e-02  9.911278e-01
+   outer loop
+     vertex -6.698168e+01  8.799611e-01  3.062543e+01
+     vertex -5.723626e+01 -9.341460e-01  3.195417e+01
+     vertex -5.723626e+01  2.749280e+00  3.184938e+01
+   endloop
+ endfacet
+ facet normal -1.376248e-01  6.648043e-02  9.882509e-01
+   outer loop
+     vertex -6.698168e+01  8.799611e-01  3.062543e+01
+     vertex -6.698168e+01  3.229799e+00  3.046735e+01
+     vertex -7.185439e+01  3.450257e+00  2.977394e+01
+   endloop
+ endfacet
+ facet normal -1.368836e-01  6.648732e-02  9.883533e-01
+   outer loop
+     vertex -6.698168e+01  8.799611e-01  3.062543e+01
+     vertex -5.723626e+01  2.749280e+00  3.184938e+01
+     vertex -6.698168e+01  3.229799e+00  3.046735e+01
+   endloop
+ endfacet
+ facet normal -1.414831e-01 -9.628805e-01 -2.298775e-01
+   outer loop
+     vertex -1.157088e+02 -2.330540e+01 -5.687158e+00
+     vertex -1.254542e+02 -2.237171e+01 -3.600019e+00
+     vertex -1.254542e+02 -2.158525e+01 -6.894239e+00
+   endloop
+ endfacet
+ facet normal -1.320627e-01 -9.746450e-01 -1.806282e-01
+   outer loop
+     vertex -1.157088e+02 -2.330540e+01 -5.687158e+00
+     vertex -1.157088e+02 -2.379563e+01 -3.041940e+00
+     vertex -1.254542e+02 -2.237171e+01 -3.600019e+00
+   endloop
+ endfacet
+ facet normal -1.356206e-01 -8.530464e-01 -5.039037e-01
+   outer loop
+     vertex -1.254542e+02 -1.859405e+01 -1.295048e+01
+     vertex -1.254542e+02 -2.031658e+01 -1.003444e+01
+     vertex -1.449450e+02 -1.801966e+01 -8.677096e+00
+   endloop
+ endfacet
+ facet normal -1.401981e-01 -8.383766e-01 -5.267534e-01
+   outer loop
+     vertex -1.254542e+02 -1.859405e+01 -1.295048e+01
+     vertex -1.449450e+02 -1.801966e+01 -8.677096e+00
+     vertex -1.449450e+02 -1.563694e+01 -1.246940e+01
+   endloop
+ endfacet
+ facet normal -1.402590e-01 -9.180243e-01 -3.708893e-01
+   outer loop
+     vertex -1.157088e+02 -2.252207e+01 -8.260852e+00
+     vertex -1.254542e+02 -2.158525e+01 -6.894239e+00
+     vertex -1.254542e+02 -2.031658e+01 -1.003444e+01
+   endloop
+ endfacet
+ facet normal -1.316395e-01 -9.483456e-01 -2.886377e-01
+   outer loop
+     vertex -1.157088e+02 -2.252207e+01 -8.260852e+00
+     vertex -1.157088e+02 -2.330540e+01 -5.687158e+00
+     vertex -1.254542e+02 -2.158525e+01 -6.894239e+00
+   endloop
+ endfacet
+ facet normal -1.787752e-01  3.333113e-01  9.257122e-01
+   outer loop
+     vertex -5.073931e+01  1.259634e+01  3.034369e+01
+     vertex -5.723626e+01  1.503854e+01  2.820965e+01
+     vertex -5.723626e+01  6.396176e+00  3.132141e+01
+   endloop
+ endfacet
+ facet normal -6.925032e-02  2.257973e-01  9.717098e-01
+   outer loop
+     vertex -5.073931e+01  1.259634e+01  3.034369e+01
+     vertex -5.723626e+01  6.396176e+00  3.132141e+01
+     vertex -4.749084e+01  9.374402e-01  3.328439e+01
+   endloop
+ endfacet
+ facet normal -1.116197e-01  4.687455e-01  8.762527e-01
+   outer loop
+     vertex -5.073931e+01  1.259634e+01  3.034369e+01
+     vertex -5.236355e+01  1.777782e+01  2.736499e+01
+     vertex -5.723626e+01  1.503854e+01  2.820965e+01
+   endloop
+ endfacet
+ facet normal -1.320824e-01 -7.687834e-01 -6.257206e-01
+   outer loop
+     vertex -1.254542e+02 -1.645613e+01 -1.557721e+01
+     vertex -1.254542e+02 -1.859405e+01 -1.295048e+01
+     vertex -1.449450e+02 -1.563694e+01 -1.246940e+01
+   endloop
+ endfacet
+ facet normal  4.344880e-02  2.557022e-01  9.657787e-01
+   outer loop
+     vertex -4.749084e+01  1.565575e+01  2.938753e+01
+     vertex -5.073931e+01  1.259634e+01  3.034369e+01
+     vertex -4.749084e+01  9.374402e-01  3.328439e+01
+   endloop
+ endfacet
+ facet normal -1.671967e-01  4.514587e-01  8.764875e-01
+   outer loop
+     vertex -4.749084e+01  1.565575e+01  2.938753e+01
+     vertex -5.236355e+01  1.777782e+01  2.736499e+01
+     vertex -5.073931e+01  1.259634e+01  3.034369e+01
+   endloop
+ endfacet
+ facet normal -2.479007e-02  6.593006e-01  7.514707e-01
+   outer loop
+     vertex -4.749084e+01  1.565575e+01  2.938753e+01
+     vertex -4.749084e+01  2.710073e+01  1.934630e+01
+     vertex -5.236355e+01  1.777782e+01  2.736499e+01
+   endloop
+ endfacet
+ facet normal -1.343823e-01 -9.097261e-01 -3.928610e-01
+   outer loop
+     vertex -1.157088e+02 -2.145550e+01 -1.073066e+01
+     vertex -1.157088e+02 -2.252207e+01 -8.260852e+00
+     vertex -1.254542e+02 -2.031658e+01 -1.003444e+01
+   endloop
+ endfacet
+ facet normal -1.356899e-01 -8.530382e-01 -5.038988e-01
+   outer loop
+     vertex -1.157088e+02 -2.145550e+01 -1.073066e+01
+     vertex -1.254542e+02 -2.031658e+01 -1.003444e+01
+     vertex -1.254542e+02 -1.859405e+01 -1.295048e+01
+   endloop
+ endfacet
+ facet normal -1.724713e-01  6.496203e-01  7.404371e-01
+   outer loop
+     vertex -4.099389e+01  1.721467e+01  2.953315e+01
+     vertex -4.749084e+01  2.710073e+01  1.934630e+01
+     vertex -4.749084e+01  1.565575e+01  2.938753e+01
+   endloop
+ endfacet
+ facet normal -1.666987e-01  6.523252e-01  7.393804e-01
+   outer loop
+     vertex -4.099389e+01  1.721467e+01  2.953315e+01
+     vertex -2.800000e+01  2.665302e+01  2.413565e+01
+     vertex -4.749084e+01  2.710073e+01  1.934630e+01
+   endloop
+ endfacet
+ facet normal -1.640745e-01  6.501441e-01  7.418842e-01
+   outer loop
+     vertex -4.099389e+01  1.721467e+01  2.953315e+01
+     vertex -2.800000e+01  2.042903e+01  2.958999e+01
+     vertex -2.800000e+01  2.665302e+01  2.413565e+01
+   endloop
+ endfacet
+ facet normal -1.059447e-01 -5.798151e-01  8.078305e-01
+   outer loop
+     vertex -6.698168e+01 -1.524675e+01  2.657495e+01
+     vertex -7.185439e+01 -1.676800e+01  2.484404e+01
+     vertex -7.185439e+01 -1.817201e+01  2.383632e+01
+   endloop
+ endfacet
+ facet normal -1.417128e-01 -4.152647e-01  8.985948e-01
+   outer loop
+     vertex -6.698168e+01 -1.524675e+01  2.657495e+01
+     vertex -5.723626e+01 -1.506066e+01  2.819784e+01
+     vertex -5.723626e+01 -1.171566e+01  2.974366e+01
+   endloop
+ endfacet
+ facet normal -1.310330e-01 -5.166806e-01  8.460919e-01
+   outer loop
+     vertex -6.698168e+01 -1.524675e+01  2.657495e+01
+     vertex -5.723626e+01 -1.820555e+01  2.627736e+01
+     vertex -5.723626e+01 -1.506066e+01  2.819784e+01
+   endloop
+ endfacet
+ facet normal -2.158830e-01  2.499086e-01  9.438963e-01
+   outer loop
+     vertex -3.774542e+01  1.076784e+01  3.291058e+01
+     vertex -4.749084e+01  1.565575e+01  2.938753e+01
+     vertex -4.749084e+01  9.374402e-01  3.328439e+01
+   endloop
+ endfacet
+ facet normal -1.193153e-01  4.129107e-01  9.029223e-01
+   outer loop
+     vertex -3.774542e+01  1.076784e+01  3.291058e+01
+     vertex -4.099389e+01  1.721467e+01  2.953315e+01
+     vertex -4.749084e+01  1.565575e+01  2.938753e+01
+   endloop
+ endfacet
+ facet normal -1.626094e-01  4.634240e-01  8.710892e-01
+   outer loop
+     vertex -3.774542e+01  1.076784e+01  3.291058e+01
+     vertex -2.800000e+01  1.312289e+01  3.347690e+01
+     vertex -2.800000e+01  2.042903e+01  2.958999e+01
+   endloop
+ endfacet
+ facet normal -1.170908e-01  2.536380e-01  9.601862e-01
+   outer loop
+     vertex -3.774542e+01  1.076784e+01  3.291058e+01
+     vertex -2.800000e+01  5.121600e+00  3.559048e+01
+     vertex -2.800000e+01  1.312289e+01  3.347690e+01
+   endloop
+ endfacet
+ facet normal -2.506394e-01  2.670511e-02  9.677121e-01
+   outer loop
+     vertex -3.774542e+01  1.076784e+01  3.291058e+01
+     vertex -2.800000e+01 -3.150983e+00  3.581877e+01
+     vertex -2.800000e+01  5.121600e+00  3.559048e+01
+   endloop
+ endfacet
+ facet normal -1.074375e-01  4.183621e-01  9.019037e-01
+   outer loop
+     vertex -3.774542e+01  1.076784e+01  3.291058e+01
+     vertex -2.800000e+01  2.042903e+01  2.958999e+01
+     vertex -4.099389e+01  1.721467e+01  2.953315e+01
+   endloop
+ endfacet
+ facet normal -9.959306e-02  1.362121e-01  9.856609e-01
+   outer loop
+     vertex -3.774542e+01  1.076784e+01  3.291058e+01
+     vertex -4.749084e+01  9.374402e-01  3.328439e+01
+     vertex -2.800000e+01 -3.150983e+00  3.581877e+01
+   endloop
+ endfacet
+ facet normal -2.501191e-01 -7.554575e-01  6.055777e-01
+   outer loop
+     vertex -3.774542e+01 -3.205775e+01  1.309020e+01
+     vertex -2.800000e+01 -3.045750e+01  1.911163e+01
+     vertex -2.800000e+01 -2.528137e+01  2.556884e+01
+   endloop
+ endfacet
+ facet normal -1.169774e-01 -8.963921e-01  4.275483e-01
+   outer loop
+     vertex -3.774542e+01 -3.205775e+01  1.309020e+01
+     vertex -2.800000e+01 -3.402023e+01  1.164204e+01
+     vertex -2.800000e+01 -3.045750e+01  1.911163e+01
+   endloop
+ endfacet
+ facet normal -1.812040e-01 -8.710886e-01  4.564753e-01
+   outer loop
+     vertex -3.774542e+01 -3.205775e+01  1.309020e+01
+     vertex -4.749084e+01 -2.596888e+01  2.084098e+01
+     vertex -5.398779e+01 -3.146503e+01  7.773659e+00
+   endloop
+ endfacet
+ facet normal -9.990476e-02 -8.395912e-01  5.339529e-01
+   outer loop
+     vertex -3.774542e+01 -3.205775e+01  1.309020e+01
+     vertex -2.800000e+01 -2.528137e+01  2.556884e+01
+     vertex -4.749084e+01 -2.596888e+01  2.084098e+01
+   endloop
+ endfacet
+ facet normal -1.392221e-01 -9.368285e-01  3.208887e-01
+   outer loop
+     vertex -3.774542e+01 -3.335117e+01  9.314096e+00
+     vertex -3.774542e+01 -3.205775e+01  1.309020e+01
+     vertex -5.398779e+01 -3.146503e+01  7.773659e+00
+   endloop
+ endfacet
+ facet normal -9.919002e-02 -9.722891e-01  2.116961e-01
+   outer loop
+     vertex -3.449695e+01 -3.426633e+01  7.467606e+00
+     vertex -2.800000e+01 -3.578086e+01  3.555754e+00
+     vertex -2.800000e+01 -3.402023e+01  1.164204e+01
+   endloop
+ endfacet
+ facet normal -1.480862e-01 -9.466319e-01  2.862838e-01
+   outer loop
+     vertex -3.449695e+01 -3.426633e+01  7.467606e+00
+     vertex -2.800000e+01 -3.402023e+01  1.164204e+01
+     vertex -3.774542e+01 -3.205775e+01  1.309020e+01
+   endloop
+ endfacet
+ facet normal -1.523685e-01 -9.656389e-01  2.105359e-01
+   outer loop
+     vertex -3.449695e+01 -3.426633e+01  7.467606e+00
+     vertex -3.774542e+01 -3.335117e+01  9.314096e+00
+     vertex -3.774542e+01 -3.420145e+01  5.414234e+00
+   endloop
+ endfacet
+ facet normal -8.204963e-02 -9.428520e-01  3.229519e-01
+   outer loop
+     vertex -3.449695e+01 -3.426633e+01  7.467606e+00
+     vertex -3.774542e+01 -3.205775e+01  1.309020e+01
+     vertex -3.774542e+01 -3.335117e+01  9.314096e+00
+   endloop
+ endfacet
+ facet normal -1.404464e-01 -9.560007e-01 -2.575606e-01
+   outer loop
+     vertex -4.749084e+01 -3.219754e+01 -8.488081e+00
+     vertex -5.723626e+01 -3.129520e+01 -6.523230e+00
+     vertex -5.723626e+01 -3.033661e+01 -1.008128e+01
+   endloop
+ endfacet
+ facet normal -1.466649e-01 -9.798250e-01  1.357657e-01
+   outer loop
+     vertex -3.449695e+01 -3.500580e+01  2.130823e+00
+     vertex -2.800000e+01 -3.578086e+01  3.555754e+00
+     vertex -3.449695e+01 -3.426633e+01  7.467606e+00
+   endloop
+ endfacet
+ facet normal -1.059418e-01 -9.849620e-01  1.364775e-01
+   outer loop
+     vertex -3.449695e+01 -3.500580e+01  2.130823e+00
+     vertex -3.449695e+01 -3.426633e+01  7.467606e+00
+     vertex -3.774542e+01 -3.420145e+01  5.414234e+00
+   endloop
+ endfacet
+ facet normal -1.446158e-01 -9.846101e-01  9.812890e-02
+   outer loop
+     vertex -3.449695e+01 -3.500580e+01  2.130823e+00
+     vertex -3.774542e+01 -3.420145e+01  5.414234e+00
+     vertex -3.774542e+01 -3.459729e+01  1.442433e+00
+   endloop
+ endfacet
+ facet normal -1.268876e-01 -8.809150e-01 -4.559478e-01
+   outer loop
+     vertex -4.749084e+01 -3.051745e+01 -1.331970e+01
+     vertex -2.800000e+01 -2.981907e+01 -2.009318e+01
+     vertex -2.800000e+01 -3.362313e+01 -1.274356e+01
+   endloop
+ endfacet
+ facet normal -1.322106e-01 -9.288756e-01 -3.459920e-01
+   outer loop
+     vertex -4.749084e+01 -3.051745e+01 -1.331970e+01
+     vertex -5.723626e+01 -3.033661e+01 -1.008128e+01
+     vertex -5.723626e+01 -2.953937e+01 -1.222161e+01
+   endloop
+ endfacet
+ facet normal -1.256638e-01 -9.370381e-01 -3.258347e-01
+   outer loop
+     vertex -4.749084e+01 -3.051745e+01 -1.331970e+01
+     vertex -4.749084e+01 -3.219754e+01 -8.488081e+00
+     vertex -5.723626e+01 -3.033661e+01 -1.008128e+01
+   endloop
+ endfacet
+ facet normal -6.544778e-02 -9.425004e-01 -3.277341e-01
+   outer loop
+     vertex -3.449695e+01 -3.491910e+01 -3.256251e+00
+     vertex -4.749084e+01 -3.219754e+01 -8.488081e+00
+     vertex -4.749084e+01 -3.051745e+01 -1.331970e+01
+   endloop
+ endfacet
+ facet normal -1.147869e-01 -9.932584e-01 -1.617494e-02
+   outer loop
+     vertex -3.449695e+01 -3.491910e+01 -3.256251e+00
+     vertex -2.800000e+01 -3.564611e+01 -4.718885e+00
+     vertex -2.800000e+01 -3.578086e+01  3.555754e+00
+   endloop
+ endfacet
+ facet normal -1.613927e-01 -9.569506e-01 -2.412426e-01
+   outer loop
+     vertex -3.449695e+01 -3.491910e+01 -3.256251e+00
+     vertex -2.800000e+01 -3.362313e+01 -1.274356e+01
+     vertex -2.800000e+01 -3.564611e+01 -4.718885e+00
+   endloop
+ endfacet
+ facet normal -1.463951e-01 -9.617268e-01 -2.316246e-01
+   outer loop
+     vertex -3.449695e+01 -3.491910e+01 -3.256251e+00
+     vertex -4.749084e+01 -3.051745e+01 -1.331970e+01
+     vertex -2.800000e+01 -3.362313e+01 -1.274356e+01
+   endloop
+ endfacet
+ facet normal -1.149824e-01 -9.932389e-01 -1.598599e-02
+   outer loop
+     vertex -3.449695e+01 -3.491910e+01 -3.256251e+00
+     vertex -2.800000e+01 -3.578086e+01  3.555754e+00
+     vertex -3.449695e+01 -3.500580e+01  2.130823e+00
+   endloop
+ endfacet
+ facet normal -1.819925e-01 -9.815525e-01 -5.859552e-02
+   outer loop
+     vertex -3.449695e+01 -3.491910e+01 -3.256251e+00
+     vertex -3.774542e+01 -3.459729e+01  1.442433e+00
+     vertex -4.749084e+01 -3.219754e+01 -8.488081e+00
+   endloop
+ endfacet
+ facet normal -1.214248e-01 -9.924721e-01 -1.597365e-02
+   outer loop
+     vertex -3.449695e+01 -3.491910e+01 -3.256251e+00
+     vertex -3.449695e+01 -3.500580e+01  2.130823e+00
+     vertex -3.774542e+01 -3.459729e+01  1.442433e+00
+   endloop
+ endfacet
+ facet normal -1.401050e-01 -8.743618e-01 -4.646096e-01
+   outer loop
+     vertex -4.749084e+01 -2.811712e+01 -1.783695e+01
+     vertex -4.749084e+01 -3.051745e+01 -1.331970e+01
+     vertex -5.723626e+01 -2.953937e+01 -1.222161e+01
+   endloop
+ endfacet
+ facet normal -1.303083e-01 -8.755423e-01 -4.652369e-01
+   outer loop
+     vertex -4.749084e+01 -2.811712e+01 -1.783695e+01
+     vertex -2.800000e+01 -2.981907e+01 -2.009318e+01
+     vertex -4.749084e+01 -3.051745e+01 -1.331970e+01
+   endloop
+ endfacet
+ facet normal -1.373401e-01 -8.017796e-01 -5.816246e-01
+   outer loop
+     vertex -4.749084e+01 -2.568388e+01 -2.119121e+01
+     vertex -2.800000e+01 -2.981907e+01 -2.009318e+01
+     vertex -4.749084e+01 -2.811712e+01 -1.783695e+01
+   endloop
+ endfacet
+ facet normal -1.262400e-01  6.451940e-01 -7.535172e-01
+   outer loop
+     vertex -9.134523e+01  2.016602e+01 -1.842195e+01
+     vertex -8.647252e+01  1.520412e+01 -2.348689e+01
+     vertex -1.010907e+02  1.497049e+01 -2.123789e+01
+   endloop
+ endfacet
+ facet normal -1.316106e-01  8.122986e-01 -5.681986e-01
+   outer loop
+     vertex -9.134523e+01  2.016602e+01 -1.842195e+01
+     vertex -9.621794e+01  2.358578e+01 -1.240439e+01
+     vertex -8.647252e+01  2.485323e+01 -1.284976e+01
+   endloop
+ endfacet
+ facet normal -1.364884e-01  8.097400e-01 -5.706943e-01
+   outer loop
+     vertex -9.134523e+01  2.016602e+01 -1.842195e+01
+     vertex -1.010907e+02  1.906114e+01 -1.765890e+01
+     vertex -9.621794e+01  2.358578e+01 -1.240439e+01
+   endloop
+ endfacet
+ facet normal -1.324055e-01  6.526736e-01 -7.459798e-01
+   outer loop
+     vertex -9.134523e+01  2.016602e+01 -1.842195e+01
+     vertex -1.010907e+02  1.497049e+01 -2.123789e+01
+     vertex -1.010907e+02  1.906114e+01 -1.765890e+01
+   endloop
+ endfacet
+ facet normal -1.365823e-01  8.136918e-01 -5.650230e-01
+   outer loop
+     vertex -8.647252e+01  2.072281e+01 -1.879799e+01
+     vertex -9.134523e+01  2.016602e+01 -1.842195e+01
+     vertex -8.647252e+01  2.485323e+01 -1.284976e+01
+   endloop
+ endfacet
+ facet normal -1.316422e-01  6.418542e-01 -7.554426e-01
+   outer loop
+     vertex -8.647252e+01  2.072281e+01 -1.879799e+01
+     vertex -8.647252e+01  1.520412e+01 -2.348689e+01
+     vertex -9.134523e+01  2.016602e+01 -1.842195e+01
+   endloop
+ endfacet
+ facet normal -1.339611e-01  6.416531e-01 -7.552058e-01
+   outer loop
+     vertex -8.159981e+01  2.121837e+01 -1.924128e+01
+     vertex -8.647252e+01  1.520412e+01 -2.348689e+01
+     vertex -8.647252e+01  2.072281e+01 -1.879799e+01
+   endloop
+ endfacet
+ facet normal -1.409969e-01  6.446442e-01 -7.513679e-01
+   outer loop
+     vertex -8.159981e+01  2.121837e+01 -1.924128e+01
+     vertex -7.185439e+01  1.701999e+01 -2.467209e+01
+     vertex -8.647252e+01  1.520412e+01 -2.348689e+01
+   endloop
+ endfacet
+ facet normal -1.339612e-01  8.140778e-01 -5.650944e-01
+   outer loop
+     vertex -8.159981e+01  2.121837e+01 -1.924128e+01
+     vertex -8.647252e+01  2.485323e+01 -1.284976e+01
+     vertex -7.672710e+01  2.603878e+01 -1.345209e+01
+   endloop
+ endfacet
+ facet normal -1.342090e-01  6.528331e-01 -7.455179e-01
+   outer loop
+     vertex -8.159981e+01  2.121837e+01 -1.924128e+01
+     vertex -7.185439e+01  2.220990e+01 -2.012740e+01
+     vertex -7.185439e+01  1.701999e+01 -2.467209e+01
+   endloop
+ endfacet
+ facet normal -1.341996e-01  8.139592e-01 -5.652087e-01
+   outer loop
+     vertex -8.159981e+01  2.121837e+01 -1.924128e+01
+     vertex -8.647252e+01  2.072281e+01 -1.879799e+01
+     vertex -8.647252e+01  2.485323e+01 -1.284976e+01
+   endloop
+ endfacet
+ facet normal -1.342024e-01  8.141419e-01 -5.649448e-01
+   outer loop
+     vertex -8.159981e+01  2.121837e+01 -1.924128e+01
+     vertex -7.672710e+01  2.603878e+01 -1.345209e+01
+     vertex -7.185439e+01  2.220990e+01 -2.012740e+01
+   endloop
+ endfacet
+ facet normal -1.518300e-01  9.738631e-01  1.689329e-01
+   outer loop
+     vertex -1.043391e+02  2.434586e+01  7.720403e+00
+     vertex -1.059634e+02  2.530915e+01  7.074209e-01
+     vertex -1.108361e+02  2.324900e+01  8.204337e+00
+   endloop
+ endfacet
+ facet normal -1.196867e-01  8.968322e-01  4.258722e-01
+   outer loop
+     vertex -1.043391e+02  2.434586e+01  7.720403e+00
+     vertex -1.108361e+02  2.324900e+01  8.204337e+00
+     vertex -1.027149e+02  2.146094e+01  1.425214e+01
+   endloop
+ endfacet
+ facet normal -1.009559e-01  9.822168e-01  1.582977e-01
+   outer loop
+     vertex -1.043391e+02  2.434586e+01  7.720403e+00
+     vertex -9.296947e+01  2.512561e+01  1.013325e+01
+     vertex -1.059634e+02  2.530915e+01  7.074209e-01
+   endloop
+ endfacet
+ facet normal -1.530813e-01  8.875630e-01  4.345090e-01
+   outer loop
+     vertex -1.043391e+02  2.434586e+01  7.720403e+00
+     vertex -9.621794e+01  2.266206e+01  1.402103e+01
+     vertex -9.296947e+01  2.512561e+01  1.013325e+01
+   endloop
+ endfacet
+ facet normal -1.492762e-01  8.902471e-01  4.303217e-01
+   outer loop
+     vertex -1.043391e+02  2.434586e+01  7.720403e+00
+     vertex -1.027149e+02  2.146094e+01  1.425214e+01
+     vertex -9.621794e+01  2.266206e+01  1.402103e+01
+   endloop
+ endfacet
+ facet normal -5.917777e-02  3.144371e-01  9.474320e-01
+   outer loop
+     vertex -1.065048e+02  1.360908e+01  2.126290e+01
+     vertex -1.157088e+02  5.826065e+00  2.327106e+01
+     vertex -1.059634e+02  1.651978e+00  2.526508e+01
+   endloop
+ endfacet
+ facet normal -1.142171e-01  3.726806e-01  9.209037e-01
+   outer loop
+     vertex -1.065048e+02  1.360908e+01  2.126290e+01
+     vertex -1.157088e+02  1.199823e+01  2.077325e+01
+     vertex -1.157088e+02  5.826065e+00  2.327106e+01
+   endloop
+ endfacet
+ facet normal -2.516838e-01  2.969194e-01  9.211374e-01
+   outer loop
+     vertex -1.065048e+02  1.360908e+01  2.126290e+01
+     vertex -1.059634e+02  1.651978e+00  2.526508e+01
+     vertex -1.010907e+02  5.153942e+00  2.546764e+01
+   endloop
+ endfacet
+ facet normal -1.480012e-01  6.087060e-01  7.794694e-01
+   outer loop
+     vertex -1.065048e+02  1.360908e+01  2.126290e+01
+     vertex -1.157088e+02  1.724606e+01  1.667509e+01
+     vertex -1.157088e+02  1.199823e+01  2.077325e+01
+   endloop
+ endfacet
+ facet normal -8.824238e-02  6.867881e-01  7.214814e-01
+   outer loop
+     vertex -1.065048e+02  1.360908e+01  2.126290e+01
+     vertex -1.027149e+02  2.146094e+01  1.425214e+01
+     vertex -1.157088e+02  1.724606e+01  1.667509e+01
+   endloop
+ endfacet
+ facet normal -2.334317e-01  7.078928e-01  6.666314e-01
+   outer loop
+     vertex -1.000078e+02  1.749763e+01  1.940868e+01
+     vertex -1.027149e+02  2.146094e+01  1.425214e+01
+     vertex -1.065048e+02  1.360908e+01  2.126290e+01
+   endloop
+ endfacet
+ facet normal -1.170335e-01  7.567839e-01  6.431028e-01
+   outer loop
+     vertex -1.000078e+02  1.749763e+01  1.940868e+01
+     vertex -9.621794e+01  2.266206e+01  1.402103e+01
+     vertex -1.027149e+02  2.146094e+01  1.425214e+01
+   endloop
+ endfacet
+ facet normal -1.104531e-01  3.849507e-01  9.163040e-01
+   outer loop
+     vertex -1.019028e+02  1.444044e+01  2.146837e+01
+     vertex -1.065048e+02  1.360908e+01  2.126290e+01
+     vertex -1.010907e+02  5.153942e+00  2.546764e+01
+   endloop
+ endfacet
+ facet normal -1.454456e-01  6.132287e-01  7.763995e-01
+   outer loop
+     vertex -1.019028e+02  1.444044e+01  2.146837e+01
+     vertex -1.000078e+02  1.749763e+01  1.940868e+01
+     vertex -1.065048e+02  1.360908e+01  2.126290e+01
+   endloop
+ endfacet
+ facet normal -1.092376e-01  9.254632e-01 -3.627466e-01
+   outer loop
+     vertex -6.860592e+01  2.970293e+01 -6.549495e+00
+     vertex -7.672710e+01  2.603878e+01 -1.345209e+01
+     vertex -7.997557e+01  2.754217e+01 -8.638297e+00
+   endloop
+ endfacet
+ facet normal -1.723229e-01  9.819625e-01 -7.780999e-02
+   outer loop
+     vertex -6.860592e+01  2.970293e+01 -6.549495e+00
+     vertex -7.997557e+01  2.754217e+01 -8.638297e+00
+     vertex -6.698168e+01  3.061029e+01  1.304296e+00
+   endloop
+ endfacet
+ facet normal -1.342016e-01  9.319555e-01 -3.368218e-01
+   outer loop
+     vertex -6.860592e+01  2.970293e+01 -6.549495e+00
+     vertex -7.023015e+01  2.682937e+01 -1.385322e+01
+     vertex -7.672710e+01  2.603878e+01 -1.345209e+01
+   endloop
+ endfacet
+ facet normal -1.339490e-01  9.319695e-01 -3.368835e-01
+   outer loop
+     vertex -6.860592e+01  2.970293e+01 -6.549495e+00
+     vertex -6.210897e+01  3.057009e+01 -6.733819e+00
+     vertex -7.023015e+01  2.682937e+01 -1.385322e+01
+   endloop
+ endfacet
+ facet normal -1.342097e-01  9.871883e-01 -8.629589e-02
+   outer loop
+     vertex -6.860592e+01  2.970293e+01 -6.549495e+00
+     vertex -6.698168e+01  3.061029e+01  1.304296e+00
+     vertex -6.210897e+01  3.057009e+01 -6.733819e+00
+   endloop
+ endfacet
+ facet normal -1.071067e-01  3.853434e-01  9.165362e-01
+   outer loop
+     vertex -9.865430e+01  1.503709e+01  2.159713e+01
+     vertex -1.019028e+02  1.444044e+01  2.146837e+01
+     vertex -1.010907e+02  5.153942e+00  2.546764e+01
+   endloop
+ endfacet
+ facet normal -1.433188e-01  6.125418e-01  7.773367e-01
+   outer loop
+     vertex -9.865430e+01  1.503709e+01  2.159713e+01
+     vertex -1.000078e+02  1.749763e+01  1.940868e+01
+     vertex -1.019028e+02  1.444044e+01  2.146837e+01
+   endloop
+ endfacet
+ facet normal -1.305967e-01  6.178179e-01  7.754003e-01
+   outer loop
+     vertex -9.134523e+01  1.869154e+01  1.991640e+01
+     vertex -1.000078e+02  1.749763e+01  1.940868e+01
+     vertex -9.865430e+01  1.503709e+01  2.159713e+01
+   endloop
+ endfacet
+ facet normal -1.420924e-01  7.626096e-01  6.310596e-01
+   outer loop
+     vertex -9.134523e+01  1.869154e+01  1.991640e+01
+     vertex -9.621794e+01  2.266206e+01  1.402103e+01
+     vertex -1.000078e+02  1.749763e+01  1.940868e+01
+   endloop
+ endfacet
+ facet normal -1.365485e-01  7.656882e-01  6.285508e-01
+   outer loop
+     vertex -9.134523e+01  1.869154e+01  1.991640e+01
+     vertex -8.647252e+01  2.368928e+01  1.488681e+01
+     vertex -9.621794e+01  2.266206e+01  1.402103e+01
+   endloop
+ endfacet
+ facet normal -1.192669e-01  6.017485e-01  7.897305e-01
+   outer loop
+     vertex -9.459370e+01  1.447783e+01  2.263652e+01
+     vertex -9.134523e+01  1.869154e+01  1.991640e+01
+     vertex -9.865430e+01  1.503709e+01  2.159713e+01
+   endloop
+ endfacet
+ facet normal -1.760677e-01  3.962920e-01  9.010843e-01
+   outer loop
+     vertex -9.459370e+01  1.447783e+01  2.263652e+01
+     vertex -9.865430e+01  1.503709e+01  2.159713e+01
+     vertex -1.010907e+02  5.153942e+00  2.546764e+01
+   endloop
+ endfacet
+ facet normal -1.053086e-01  5.953705e-01  7.965200e-01
+   outer loop
+     vertex -9.459370e+01  1.447783e+01  2.263652e+01
+     vertex -8.647252e+01  1.318290e+01  2.467813e+01
+     vertex -9.134523e+01  1.869154e+01  1.991640e+01
+   endloop
+ endfacet
+ facet normal -1.365823e-01  5.759171e-01  8.060179e-01
+   outer loop
+     vertex -8.647252e+01  1.907504e+01  2.046808e+01
+     vertex -9.134523e+01  1.869154e+01  1.991640e+01
+     vertex -8.647252e+01  1.318290e+01  2.467813e+01
+   endloop
+ endfacet
+ facet normal -1.316422e-01  7.640080e-01  6.316344e-01
+   outer loop
+     vertex -8.647252e+01  1.907504e+01  2.046808e+01
+     vertex -8.647252e+01  2.368928e+01  1.488681e+01
+     vertex -9.134523e+01  1.869154e+01  1.991640e+01
+   endloop
+ endfacet
+ facet normal -1.339407e-01  9.872568e-01 -8.592955e-02
+   outer loop
+     vertex -5.561202e+01  3.143732e+01 -6.917772e+00
+     vertex -5.398779e+01  3.238110e+01  1.393683e+00
+     vertex -4.749084e+01  3.326648e+01  1.438947e+00
+   endloop
+ endfacet
+ facet normal -1.342099e-01  9.872251e-01 -8.587332e-02
+   outer loop
+     vertex -5.561202e+01  3.143732e+01 -6.917772e+00
+     vertex -6.210897e+01  3.057009e+01 -6.733819e+00
+     vertex -5.398779e+01  3.238110e+01  1.393683e+00
+   endloop
+ endfacet
+ facet normal -4.967194e-02  9.846616e-01 -1.672551e-01
+   outer loop
+     vertex -5.561202e+01  3.143732e+01 -6.917772e+00
+     vertex -4.749084e+01  3.326648e+01  1.438947e+00
+     vertex -4.749084e+01  3.092553e+01 -1.234263e+01
+   endloop
+ endfacet
+ facet normal -1.617255e-01  9.300762e-01 -3.298530e-01
+   outer loop
+     vertex -5.561202e+01  3.143732e+01 -6.917772e+00
+     vertex -4.749084e+01  3.092553e+01 -1.234263e+01
+     vertex -5.723626e+01  2.841106e+01 -1.465447e+01
+   endloop
+ endfacet
+ facet normal -1.339492e-01  9.321146e-01 -3.364817e-01
+   outer loop
+     vertex -5.561202e+01  3.143732e+01 -6.917772e+00
+     vertex -5.723626e+01  2.841106e+01 -1.465447e+01
+     vertex -6.210897e+01  3.057009e+01 -6.733819e+00
+   endloop
+ endfacet
+ facet normal -1.718899e-01  9.718532e-01  1.611063e-01
+   outer loop
+     vertex -6.860592e+01  2.903911e+01  9.049318e+00
+     vertex -6.698168e+01  3.061029e+01  1.304296e+00
+     vertex -7.997557e+01  2.671692e+01  1.092692e+01
+   endloop
+ endfacet
+ facet normal -1.339510e-01  9.763037e-01  1.699654e-01
+   outer loop
+     vertex -6.860592e+01  2.903911e+01  9.049318e+00
+     vertex -6.210897e+01  2.988347e+01  9.319483e+00
+     vertex -6.698168e+01  3.061029e+01  1.304296e+00
+   endloop
+ endfacet
+ facet normal -1.339594e-01  9.000009e-01  4.147931e-01
+   outer loop
+     vertex -6.860592e+01  2.903911e+01  9.049318e+00
+     vertex -7.672710e+01  2.481016e+01  1.560234e+01
+     vertex -7.023015e+01  2.555715e+01  1.607976e+01
+   endloop
+ endfacet
+ facet normal -1.342115e-01  8.999922e-01  4.147305e-01
+   outer loop
+     vertex -6.860592e+01  2.903911e+01  9.049318e+00
+     vertex -7.023015e+01  2.555715e+01  1.607976e+01
+     vertex -6.210897e+01  2.988347e+01  9.319483e+00
+   endloop
+ endfacet
+ facet normal -1.094776e-01  8.914798e-01  4.396344e-01
+   outer loop
+     vertex -6.860592e+01  2.903911e+01  9.049318e+00
+     vertex -7.997557e+01  2.671692e+01  1.092692e+01
+     vertex -7.672710e+01  2.481016e+01  1.560234e+01
+   endloop
+ endfacet
+ facet normal -1.339611e-01  7.637686e-01  6.314365e-01
+   outer loop
+     vertex -8.159981e+01  1.952496e+01  2.095762e+01
+     vertex -8.647252e+01  2.368928e+01  1.488681e+01
+     vertex -8.647252e+01  1.907504e+01  2.046808e+01
+   endloop
+ endfacet
+ facet normal -1.341996e-01  7.636408e-01  6.315403e-01
+   outer loop
+     vertex -8.159981e+01  1.952496e+01  2.095762e+01
+     vertex -7.672710e+01  2.481016e+01  1.560234e+01
+     vertex -8.647252e+01  2.368928e+01  1.488681e+01
+   endloop
+ endfacet
+ facet normal -1.339584e-01  7.635642e-01  6.316841e-01
+   outer loop
+     vertex -8.159981e+01  1.952496e+01  2.095762e+01
+     vertex -7.185439e+01  2.042433e+01  2.193715e+01
+     vertex -7.672710e+01  2.481016e+01  1.560234e+01
+   endloop
+ endfacet
+ facet normal -1.341996e-01  5.761064e-01  8.062828e-01
+   outer loop
+     vertex -8.159981e+01  1.952496e+01  2.095762e+01
+     vertex -8.647252e+01  1.907504e+01  2.046808e+01
+     vertex -8.647252e+01  1.318290e+01  2.467813e+01
+   endloop
+ endfacet
+ facet normal -1.308320e-01 -3.343437e-02  9.908406e-01
+   outer loop
+     vertex -1.059634e+02 -5.239920e+00  2.477088e+01
+     vertex -9.621794e+01 -5.645150e+00  2.604401e+01
+     vertex -1.010907e+02  3.717894e+00  2.571655e+01
+   endloop
+ endfacet
+ facet normal -1.125142e-01 -3.363670e-01  9.349854e-01
+   outer loop
+     vertex -1.059634e+02 -5.239920e+00  2.477088e+01
+     vertex -1.157088e+02 -7.447527e+00  2.280394e+01
+     vertex -1.059634e+02 -1.174158e+01  2.243187e+01
+   endloop
+ endfacet
+ facet normal -1.342494e-01 -1.455120e-01  9.802058e-01
+   outer loop
+     vertex -1.059634e+02 -5.239920e+00  2.477088e+01
+     vertex -1.157088e+02 -2.186604e+00  2.388941e+01
+     vertex -1.157088e+02 -4.847544e+00  2.349440e+01
+   endloop
+ endfacet
+ facet normal -5.625533e-02 -3.379805e-01  9.394703e-01
+   outer loop
+     vertex -1.059634e+02 -5.239920e+00  2.477088e+01
+     vertex -1.059634e+02 -1.174158e+01  2.243187e+01
+     vertex -1.010907e+02 -1.392299e+01  2.193887e+01
+   endloop
+ endfacet
+ facet normal -1.353983e-01 -3.750811e-01  9.170504e-01
+   outer loop
+     vertex -1.059634e+02 -5.239920e+00  2.477088e+01
+     vertex -1.010907e+02 -1.392299e+01  2.193887e+01
+     vertex -9.621794e+01 -5.645150e+00  2.604401e+01
+   endloop
+ endfacet
+ facet normal -6.197126e-02 -7.138615e-02  9.955218e-01
+   outer loop
+     vertex -1.059634e+02 -5.239920e+00  2.477088e+01
+     vertex -1.010907e+02  3.717894e+00  2.571655e+01
+     vertex -1.059634e+02  1.651978e+00  2.526508e+01
+   endloop
+ endfacet
+ facet normal -1.119194e-01 -7.107426e-02  9.911723e-01
+   outer loop
+     vertex -1.059634e+02 -5.239920e+00  2.477088e+01
+     vertex -1.059634e+02  1.651978e+00  2.526508e+01
+     vertex -1.157088e+02 -2.186604e+00  2.388941e+01
+   endloop
+ endfacet
+ facet normal -1.356636e-01 -2.542927e-01  9.575649e-01
+   outer loop
+     vertex -1.059634e+02 -5.239920e+00  2.477088e+01
+     vertex -1.157088e+02 -4.847544e+00  2.349440e+01
+     vertex -1.157088e+02 -7.447527e+00  2.280394e+01
+   endloop
+ endfacet
+ facet normal -1.854985e-01 -8.601163e-01  4.751740e-01
+   outer loop
+     vertex -1.200401e+02 -1.783789e+01  1.514228e+01
+     vertex -1.254542e+02 -1.639365e+01  1.564295e+01
+     vertex -1.189573e+02 -2.235937e+01  7.380634e+00
+   endloop
+ endfacet
+ facet normal -1.093691e-01 -6.658482e-01  7.380275e-01
+   outer loop
+     vertex -1.200401e+02 -1.783789e+01  1.514228e+01
+     vertex -1.254542e+02 -1.387917e+01  1.791151e+01
+     vertex -1.254542e+02 -1.639365e+01  1.564295e+01
+   endloop
+ endfacet
+ facet normal -9.964071e-02 -6.582458e-01  7.461797e-01
+   outer loop
+     vertex -1.200401e+02 -1.783789e+01  1.514228e+01
+     vertex -1.157088e+02 -1.233500e+01  2.057506e+01
+     vertex -1.254542e+02 -1.387917e+01  1.791151e+01
+   endloop
+ endfacet
+ facet normal -1.347291e-01  1.692279e-01  9.763247e-01
+   outer loop
+     vertex -9.134523e+01  3.773222e+00  2.705179e+01
+     vertex -1.010907e+02  5.153942e+00  2.546764e+01
+     vertex -1.010907e+02  3.717894e+00  2.571655e+01
+   endloop
+ endfacet
+ facet normal -1.354567e-01 -3.586591e-02  9.901339e-01
+   outer loop
+     vertex -9.134523e+01  3.773222e+00  2.705179e+01
+     vertex -1.010907e+02  3.717894e+00  2.571655e+01
+     vertex -9.621794e+01 -5.645150e+00  2.604401e+01
+   endloop
+ endfacet
+ facet normal -1.011949e-01  3.529471e-01  9.301548e-01
+   outer loop
+     vertex -9.134523e+01  3.773222e+00  2.705179e+01
+     vertex -9.459370e+01  1.447783e+01  2.263652e+01
+     vertex -1.010907e+02  5.153942e+00  2.546764e+01
+   endloop
+ endfacet
+ facet normal -1.808915e-01  3.276003e-01  9.273383e-01
+   outer loop
+     vertex -9.134523e+01  3.773222e+00  2.705179e+01
+     vertex -8.647252e+01  1.318290e+01  2.467813e+01
+     vertex -9.459370e+01  1.447783e+01  2.263652e+01
+   endloop
+ endfacet
+ facet normal -1.307149e-01 -3.837725e-02  9.906769e-01
+   outer loop
+     vertex -9.134523e+01  3.773222e+00  2.705179e+01
+     vertex -9.621794e+01 -5.645150e+00  2.604401e+01
+     vertex -8.647252e+01 -6.063209e+00  2.731367e+01
+   endloop
+ endfacet
+ facet normal -1.774943e-01 -8.609259e-01  4.767623e-01
+   outer loop
+     vertex -1.173330e+02 -1.855880e+01  1.484831e+01
+     vertex -1.200401e+02 -1.783789e+01  1.514228e+01
+     vertex -1.189573e+02 -2.235937e+01  7.380634e+00
+   endloop
+ endfacet
+ facet normal -1.390957e-01 -6.098092e-01  7.802469e-01
+   outer loop
+     vertex -1.135431e+02 -1.713094e+01  1.721282e+01
+     vertex -1.059634e+02 -1.338503e+01  2.149173e+01
+     vertex -1.157088e+02 -1.233500e+01  2.057506e+01
+   endloop
+ endfacet
+ facet normal -1.771060e-01 -6.173380e-01  7.665033e-01
+   outer loop
+     vertex -1.135431e+02 -1.713094e+01  1.721282e+01
+     vertex -1.157088e+02 -1.233500e+01  2.057506e+01
+     vertex -1.200401e+02 -1.783789e+01  1.514228e+01
+   endloop
+ endfacet
+ facet normal -1.274349e-01 -7.453688e-01  6.543590e-01
+   outer loop
+     vertex -1.135431e+02 -1.713094e+01  1.721282e+01
+     vertex -1.200401e+02 -1.783789e+01  1.514228e+01
+     vertex -1.173330e+02 -1.855880e+01  1.484831e+01
+   endloop
+ endfacet
+ facet normal -1.616210e-01  8.983691e-01  4.084258e-01
+   outer loop
+     vertex -5.561202e+01  3.072772e+01  9.590012e+00
+     vertex -5.723626e+01  2.705053e+01  1.703557e+01
+     vertex -4.749084e+01  2.974425e+01  1.496691e+01
+   endloop
+ endfacet
+ facet normal -1.342198e-01  9.762042e-01  1.703246e-01
+   outer loop
+     vertex -5.561202e+01  3.072772e+01  9.590012e+00
+     vertex -4.749084e+01  3.326648e+01  1.438947e+00
+     vertex -5.398779e+01  3.238110e+01  1.393683e+00
+   endloop
+ endfacet
+ facet normal -4.957005e-02  9.665465e-01  2.516560e-01
+   outer loop
+     vertex -5.561202e+01  3.072772e+01  9.590012e+00
+     vertex -4.749084e+01  2.974425e+01  1.496691e+01
+     vertex -4.749084e+01  3.326648e+01  1.438947e+00
+   endloop
+ endfacet
+ facet normal -1.339511e-01  9.762308e-01  1.703832e-01
+   outer loop
+     vertex -5.561202e+01  3.072772e+01  9.590012e+00
+     vertex -5.398779e+01  3.238110e+01  1.393683e+00
+     vertex -6.210897e+01  2.988347e+01  9.319483e+00
+   endloop
+ endfacet
+ facet normal -1.342117e-01  8.998133e-01  4.151184e-01
+   outer loop
+     vertex -5.561202e+01  3.072772e+01  9.590012e+00
+     vertex -6.210897e+01  2.988347e+01  9.319483e+00
+     vertex -5.723626e+01  2.705053e+01  1.703557e+01
+   endloop
+ endfacet
+ facet normal -1.307306e-01  3.056109e-01  9.431392e-01
+   outer loop
+     vertex -8.647252e+01  3.795923e+00  2.771985e+01
+     vertex -8.647252e+01  1.318290e+01  2.467813e+01
+     vertex -9.134523e+01  3.773222e+00  2.705179e+01
+   endloop
+ endfacet
+ facet normal -1.355325e-01 -4.078353e-02  9.899332e-01
+   outer loop
+     vertex -8.647252e+01  3.795923e+00  2.771985e+01
+     vertex -9.134523e+01  3.773222e+00  2.705179e+01
+     vertex -8.647252e+01 -6.063209e+00  2.731367e+01
+   endloop
+ endfacet
+ facet normal -1.326374e-01 -7.399673e-01  6.594359e-01
+   outer loop
+     vertex -1.124603e+02 -1.920667e+01  1.510140e+01
+     vertex -1.135431e+02 -1.713094e+01  1.721282e+01
+     vertex -1.173330e+02 -1.855880e+01  1.484831e+01
+   endloop
+ endfacet
+ facet normal -1.110094e-01 -6.419713e-01  7.586500e-01
+   outer loop
+     vertex -1.086704e+02 -1.839243e+01  1.685834e+01
+     vertex -1.059634e+02 -1.338503e+01  2.149173e+01
+     vertex -1.135431e+02 -1.713094e+01  1.721282e+01
+   endloop
+ endfacet
+ facet normal -1.443481e-01 -7.416439e-01  6.550785e-01
+   outer loop
+     vertex -1.086704e+02 -1.839243e+01  1.685834e+01
+     vertex -1.135431e+02 -1.713094e+01  1.721282e+01
+     vertex -1.124603e+02 -1.920667e+01  1.510140e+01
+   endloop
+ endfacet
+ facet normal -1.715266e-01 -6.175426e-01  7.676066e-01
+   outer loop
+     vertex -1.086704e+02 -1.839243e+01  1.685834e+01
+     vertex -1.010907e+02 -1.629175e+01  2.024210e+01
+     vertex -1.059634e+02 -1.338503e+01  2.149173e+01
+   endloop
+ endfacet
+ facet normal -1.339634e-01  5.757584e-01  8.065706e-01
+   outer loop
+     vertex -7.185439e+01  1.411147e+01  2.644349e+01
+     vertex -5.723626e+01  1.503854e+01  2.820965e+01
+     vertex -7.185439e+01  2.042433e+01  2.193715e+01
+   endloop
+ endfacet
+ facet normal -1.342002e-01  5.757397e-01  8.065445e-01
+   outer loop
+     vertex -7.185439e+01  1.411147e+01  2.644349e+01
+     vertex -7.185439e+01  2.042433e+01  2.193715e+01
+     vertex -8.159981e+01  1.952496e+01  2.095762e+01
+   endloop
+ endfacet
+ facet normal -1.339730e-01  5.759993e-01  8.063970e-01
+   outer loop
+     vertex -7.185439e+01  1.411147e+01  2.644349e+01
+     vertex -8.159981e+01  1.952496e+01  2.095762e+01
+     vertex -8.647252e+01  1.318290e+01  2.467813e+01
+   endloop
+ endfacet
+ facet normal -1.329206e-01  2.908459e-01  9.474918e-01
+   outer loop
+     vertex -7.185439e+01  1.411147e+01  2.644349e+01
+     vertex -6.698168e+01  3.229799e+00  3.046735e+01
+     vertex -5.723626e+01  1.503854e+01  2.820965e+01
+   endloop
+ endfacet
+ facet normal  1.490714e-02  3.526569e-01  9.356340e-01
+   outer loop
+     vertex -7.185439e+01  1.411147e+01  2.644349e+01
+     vertex -7.185439e+01  6.853659e+00  2.917909e+01
+     vertex -6.698168e+01  3.229799e+00  3.046735e+01
+   endloop
+ endfacet
+ facet normal -1.261407e-01 -4.782627e-02  9.908588e-01
+   outer loop
+     vertex -8.159981e+01  3.689988e+00  2.840475e+01
+     vertex -8.647252e+01 -6.063209e+00  2.731367e+01
+     vertex -7.672710e+01 -6.746083e+00  2.852135e+01
+   endloop
+ endfacet
+ facet normal -1.402360e-01 -5.443249e-02  9.886207e-01
+   outer loop
+     vertex -8.159981e+01  3.689988e+00  2.840475e+01
+     vertex -7.672710e+01 -6.746083e+00  2.852135e+01
+     vertex -7.185439e+01  3.450257e+00  2.977394e+01
+   endloop
+ endfacet
+ facet normal -1.414934e-01  1.984819e-01  9.698374e-01
+   outer loop
+     vertex -8.159981e+01  3.689988e+00  2.840475e+01
+     vertex -7.185439e+01  5.160536e+00  2.952560e+01
+     vertex -7.185439e+01  6.853659e+00  2.917909e+01
+   endloop
+ endfacet
+ facet normal -1.399435e-01 -4.075828e-02  9.893203e-01
+   outer loop
+     vertex -8.159981e+01  3.689988e+00  2.840475e+01
+     vertex -8.647252e+01  3.795923e+00  2.771985e+01
+     vertex -8.647252e+01 -6.063209e+00  2.731367e+01
+   endloop
+ endfacet
+ facet normal -1.331853e-01  3.021816e-01  9.439004e-01
+   outer loop
+     vertex -8.159981e+01  3.689988e+00  2.840475e+01
+     vertex -7.185439e+01  1.411147e+01  2.644349e+01
+     vertex -8.647252e+01  1.318290e+01  2.467813e+01
+   endloop
+ endfacet
+ facet normal -1.855668e-01  3.465703e-01  9.194857e-01
+   outer loop
+     vertex -8.159981e+01  3.689988e+00  2.840475e+01
+     vertex -7.185439e+01  6.853659e+00  2.917909e+01
+     vertex -7.185439e+01  1.411147e+01  2.644349e+01
+   endloop
+ endfacet
+ facet normal -1.259999e-01  3.057996e-01  9.437217e-01
+   outer loop
+     vertex -8.159981e+01  3.689988e+00  2.840475e+01
+     vertex -8.647252e+01  1.318290e+01  2.467813e+01
+     vertex -8.647252e+01  3.795923e+00  2.771985e+01
+   endloop
+ endfacet
+ facet normal -1.342755e-01  1.424000e-01  9.806591e-01
+   outer loop
+     vertex -8.159981e+01  3.689988e+00  2.840475e+01
+     vertex -7.185439e+01  3.450257e+00  2.977394e+01
+     vertex -7.185439e+01  5.160536e+00  2.952560e+01
+   endloop
+ endfacet
+ facet normal -1.169745e-01 -7.805438e-01  6.140589e-01
+   outer loop
+     vertex -1.100240e+02 -2.035558e+01  1.410510e+01
+     vertex -1.086704e+02 -1.839243e+01  1.685834e+01
+     vertex -1.124603e+02 -1.920667e+01  1.510140e+01
+   endloop
+ endfacet
+ facet normal -1.836480e-01 -8.593395e-01  4.772934e-01
+   outer loop
+     vertex -1.119189e+02 -2.220965e+01  1.035834e+01
+     vertex -1.173330e+02 -1.855880e+01  1.484831e+01
+     vertex -1.189573e+02 -2.235937e+01  7.380634e+00
+   endloop
+ endfacet
+ facet normal -1.391120e-01 -8.437809e-01  5.183452e-01
+   outer loop
+     vertex -1.119189e+02 -2.220965e+01  1.035834e+01
+     vertex -1.124603e+02 -1.920667e+01  1.510140e+01
+     vertex -1.173330e+02 -1.855880e+01  1.484831e+01
+   endloop
+ endfacet
+ facet normal -1.872664e-01 -8.394700e-01  5.101191e-01
+   outer loop
+     vertex -1.119189e+02 -2.220965e+01  1.035834e+01
+     vertex -1.100240e+02 -2.035558e+01  1.410510e+01
+     vertex -1.124603e+02 -1.920667e+01  1.510140e+01
+   endloop
+ endfacet
+ facet normal -8.044770e-02 -9.677282e-01  2.388103e-01
+   outer loop
+     vertex -1.119189e+02 -2.220965e+01  1.035834e+01
+     vertex -1.189573e+02 -2.235937e+01  7.380634e+00
+     vertex -1.157088e+02 -2.387590e+01  2.329518e+00
+   endloop
+ endfacet
+ facet normal -1.145919e-02 -8.114911e-01  5.842525e-01
+   outer loop
+     vertex -1.083997e+02 -2.198524e+01  1.187347e+01
+     vertex -1.086704e+02 -1.839243e+01  1.685834e+01
+     vertex -1.100240e+02 -2.035558e+01  1.410510e+01
+   endloop
+ endfacet
+ facet normal -1.620877e-01 -8.493742e-01  5.022859e-01
+   outer loop
+     vertex -1.083997e+02 -2.198524e+01  1.187347e+01
+     vertex -1.100240e+02 -2.035558e+01  1.410510e+01
+     vertex -1.119189e+02 -2.220965e+01  1.035834e+01
+   endloop
+ endfacet
+ facet normal -1.307734e-01 -3.776197e-01  9.166797e-01
+   outer loop
+     vertex -9.134523e+01 -1.475041e+01  2.298830e+01
+     vertex -9.621794e+01 -5.645150e+00  2.604401e+01
+     vertex -1.010907e+02 -1.392299e+01  2.193887e+01
+   endloop
+ endfacet
+ facet normal -1.355151e-01 -3.796449e-01  9.151532e-01
+   outer loop
+     vertex -9.134523e+01 -1.475041e+01  2.298830e+01
+     vertex -8.647252e+01 -6.063209e+00  2.731367e+01
+     vertex -9.621794e+01 -5.645150e+00  2.604401e+01
+   endloop
+ endfacet
+ facet normal -1.354922e-01 -5.541423e-01  8.213210e-01
+   outer loop
+     vertex -9.134523e+01 -1.475041e+01  2.298830e+01
+     vertex -1.010907e+02 -1.392299e+01  2.193887e+01
+     vertex -1.010907e+02 -1.513118e+01  2.112371e+01
+   endloop
+ endfacet
+ facet normal -1.028415e-01 -6.660514e-01  7.387822e-01
+   outer loop
+     vertex -9.134523e+01 -1.475041e+01  2.298830e+01
+     vertex -1.010907e+02 -1.629175e+01  2.024210e+01
+     vertex -8.647252e+01 -2.238647e+01  1.678229e+01
+   endloop
+ endfacet
+ facet normal -1.276688e-01 -5.999492e-01  7.897858e-01
+   outer loop
+     vertex -9.134523e+01 -1.475041e+01  2.298830e+01
+     vertex -1.010907e+02 -1.513118e+01  2.112371e+01
+     vertex -1.010907e+02 -1.629175e+01  2.024210e+01
+   endloop
+ endfacet
+ facet normal -1.508357e-01 -8.058349e-01  5.726069e-01
+   outer loop
+     vertex -1.010907e+02 -2.222560e+01  1.346055e+01
+     vertex -1.086704e+02 -1.839243e+01  1.685834e+01
+     vertex -1.083997e+02 -2.198524e+01  1.187347e+01
+   endloop
+ endfacet
+ facet normal -1.559837e-01 -7.433652e-01  6.504439e-01
+   outer loop
+     vertex -1.010907e+02 -2.222560e+01  1.346055e+01
+     vertex -8.647252e+01 -2.238647e+01  1.678229e+01
+     vertex -1.010907e+02 -1.629175e+01  2.024210e+01
+   endloop
+ endfacet
+ facet normal -8.508769e-02 -7.498478e-01  6.561161e-01
+   outer loop
+     vertex -1.010907e+02 -2.222560e+01  1.346055e+01
+     vertex -1.010907e+02 -1.629175e+01  2.024210e+01
+     vertex -1.086704e+02 -1.839243e+01  1.685834e+01
+   endloop
+ endfacet
+ facet normal -1.355325e-01 -6.755262e-01  7.247726e-01
+   outer loop
+     vertex -8.647252e+01 -1.516818e+01  2.351012e+01
+     vertex -9.134523e+01 -1.475041e+01  2.298830e+01
+     vertex -8.647252e+01 -2.238647e+01  1.678229e+01
+   endloop
+ endfacet
+ facet normal -1.307306e-01 -3.821549e-01  9.148044e-01
+   outer loop
+     vertex -8.647252e+01 -1.516818e+01  2.351012e+01
+     vertex -8.647252e+01 -6.063209e+00  2.731367e+01
+     vertex -9.134523e+01 -1.475041e+01  2.298830e+01
+   endloop
+ endfacet
+ facet normal -1.752209e-01 -9.442652e-01  2.786771e-01
+   outer loop
+     vertex -1.059634e+02 -2.458206e+01  6.064310e+00
+     vertex -1.119189e+02 -2.220965e+01  1.035834e+01
+     vertex -1.157088e+02 -2.387590e+01  2.329518e+00
+   endloop
+ endfacet
+ facet normal -1.006508e-01 -9.233457e-01  3.705430e-01
+   outer loop
+     vertex -1.059634e+02 -2.458206e+01  6.064310e+00
+     vertex -1.083997e+02 -2.198524e+01  1.187347e+01
+     vertex -1.119189e+02 -2.220965e+01  1.035834e+01
+   endloop
+ endfacet
+ facet normal -1.244250e-01 -8.902265e-01  4.381955e-01
+   outer loop
+     vertex -1.010907e+02 -2.422295e+01  9.402783e+00
+     vertex -1.010907e+02 -2.222560e+01  1.346055e+01
+     vertex -1.083997e+02 -2.198524e+01  1.187347e+01
+   endloop
+ endfacet
+ facet normal -1.669882e-01 -9.243158e-01  3.431549e-01
+   outer loop
+     vertex -1.010907e+02 -2.422295e+01  9.402783e+00
+     vertex -1.083997e+02 -2.198524e+01  1.187347e+01
+     vertex -1.059634e+02 -2.458206e+01  6.064310e+00
+   endloop
+ endfacet
+ facet normal -1.584668e-01 -9.301085e-01  3.313404e-01
+   outer loop
+     vertex -1.010907e+02 -2.471208e+01  8.029756e+00
+     vertex -1.010907e+02 -2.422295e+01  9.402783e+00
+     vertex -1.059634e+02 -2.458206e+01  6.064310e+00
+   endloop
+ endfacet
+ facet normal -1.259999e-01 -3.823910e-01  9.153694e-01
+   outer loop
+     vertex -8.159981e+01 -1.569453e+01  2.396096e+01
+     vertex -8.647252e+01 -6.063209e+00  2.731367e+01
+     vertex -8.647252e+01 -1.516818e+01  2.351012e+01
+   endloop
+ endfacet
+ facet normal -1.259785e-01 -3.951344e-01  9.099441e-01
+   outer loop
+     vertex -8.159981e+01 -1.569453e+01  2.396096e+01
+     vertex -7.185439e+01 -1.676800e+01  2.484404e+01
+     vertex -7.672710e+01 -6.746083e+00  2.852135e+01
+   endloop
+ endfacet
+ facet normal -1.400746e-01 -3.879776e-01  9.109624e-01
+   outer loop
+     vertex -8.159981e+01 -1.569453e+01  2.396096e+01
+     vertex -7.672710e+01 -6.746083e+00  2.852135e+01
+     vertex -8.647252e+01 -6.063209e+00  2.731367e+01
+   endloop
+ endfacet
+ facet normal -1.365528e-01 -5.776347e-01  8.047928e-01
+   outer loop
+     vertex -8.159981e+01 -1.569453e+01  2.396096e+01
+     vertex -7.185439e+01 -1.817201e+01  2.383632e+01
+     vertex -7.185439e+01 -1.676800e+01  2.484404e+01
+   endloop
+ endfacet
+ facet normal -1.399435e-01 -6.751079e-01  7.243239e-01
+   outer loop
+     vertex -8.159981e+01 -1.569453e+01  2.396096e+01
+     vertex -8.647252e+01 -1.516818e+01  2.351012e+01
+     vertex -8.647252e+01 -2.238647e+01  1.678229e+01
+   endloop
+ endfacet
+ facet normal -7.173053e-02 -7.053007e-01 -7.052699e-01
+   outer loop
+     vertex -1.351996e+02 -1.057273e+01 -1.852501e+01
+     vertex -1.449450e+02 -1.563694e+01 -1.246940e+01
+     vertex -1.449450e+02 -1.247008e+01 -1.563640e+01
+   endloop
+ endfacet
+ facet normal -1.481939e-01 -6.281775e-01 -7.638270e-01
+   outer loop
+     vertex -1.351996e+02 -1.057273e+01 -1.852501e+01
+     vertex -1.254542e+02 -1.645613e+01 -1.557721e+01
+     vertex -1.449450e+02 -1.563694e+01 -1.246940e+01
+   endloop
+ endfacet
+ facet normal -1.458125e-01 -5.263583e-01 -8.376668e-01
+   outer loop
+     vertex -1.351996e+02 -1.057273e+01 -1.852501e+01
+     vertex -1.449450e+02 -1.247008e+01 -1.563640e+01
+     vertex -1.449450e+02 -8.677881e+00 -1.801928e+01
+   endloop
+ endfacet
+ facet normal -1.263565e-01 -4.086112e-01 -9.039198e-01
+   outer loop
+     vertex -1.384481e+02 -7.078382e+00 -1.965051e+01
+     vertex -1.351996e+02 -1.057273e+01 -1.852501e+01
+     vertex -1.449450e+02 -8.677881e+00 -1.801928e+01
+   endloop
+ endfacet
+ facet normal -1.538200e-01 -3.263558e-01 -9.326475e-01
+   outer loop
+     vertex -1.384481e+02 -7.078382e+00 -1.965051e+01
+     vertex -1.449450e+02 -8.677881e+00 -1.801928e+01
+     vertex -1.449450e+02 -4.450508e+00 -1.949854e+01
+   endloop
+ endfacet
+ facet normal -6.837182e-02 -1.117036e-01 -9.913867e-01
+   outer loop
+     vertex -1.384481e+02 -7.078382e+00 -1.965051e+01
+     vertex -1.449450e+02 -4.450508e+00 -1.949854e+01
+     vertex -1.449450e+02  4.657024e-05 -2.000000e+01
+   endloop
+ endfacet
+ facet normal -1.403973e-01 -4.005050e-01  9.054747e-01
+   outer loop
+     vertex -6.698168e+01 -7.463427e+00  2.971512e+01
+     vertex -7.672710e+01 -6.746083e+00  2.852135e+01
+     vertex -7.185439e+01 -1.676800e+01  2.484404e+01
+   endloop
+ endfacet
+ facet normal -1.618067e-01 -1.070323e-01  9.810009e-01
+   outer loop
+     vertex -6.698168e+01 -7.463427e+00  2.971512e+01
+     vertex -5.723626e+01 -4.605160e+00  3.163439e+01
+     vertex -6.698168e+01  8.799611e-01  3.062543e+01
+   endloop
+ endfacet
+ facet normal -1.286780e-01 -1.075598e-01  9.858361e-01
+   outer loop
+     vertex -6.698168e+01 -7.463427e+00  2.971512e+01
+     vertex -6.698168e+01  8.799611e-01  3.062543e+01
+     vertex -7.672710e+01 -6.746083e+00  2.852135e+01
+   endloop
+ endfacet
+ facet normal -2.079686e-01 -3.659659e-01  9.070932e-01
+   outer loop
+     vertex -6.698168e+01 -7.463427e+00  2.971512e+01
+     vertex -7.185439e+01 -1.676800e+01  2.484404e+01
+     vertex -6.698168e+01 -1.524675e+01  2.657495e+01
+   endloop
+ endfacet
+ facet normal -1.377014e-01 -3.092742e-01  9.409505e-01
+   outer loop
+     vertex -6.698168e+01 -7.463427e+00  2.971512e+01
+     vertex -5.723626e+01 -1.171566e+01  2.974366e+01
+     vertex -5.723626e+01 -8.214985e+00  3.089427e+01
+   endloop
+ endfacet
+ facet normal -1.637278e-01 -3.690975e-01  9.148553e-01
+   outer loop
+     vertex -6.698168e+01 -7.463427e+00  2.971512e+01
+     vertex -6.698168e+01 -1.524675e+01  2.657495e+01
+     vertex -5.723626e+01 -1.171566e+01  2.974366e+01
+   endloop
+ endfacet
+ facet normal -1.328313e-01 -1.990704e-01  9.709412e-01
+   outer loop
+     vertex -6.698168e+01 -7.463427e+00  2.971512e+01
+     vertex -5.723626e+01 -8.214985e+00  3.089427e+01
+     vertex -5.723626e+01 -4.605160e+00  3.163439e+01
+   endloop
+ endfacet
+ facet normal -4.306227e-03 -5.325562e-02 -9.985716e-01
+   outer loop
+     vertex -1.351996e+02 -8.432039e+00 -1.959233e+01
+     vertex -1.384481e+02 -7.078382e+00 -1.965051e+01
+     vertex -1.449450e+02  4.657024e-05 -2.000000e+01
+   endloop
+ endfacet
+ facet normal  1.323979e-03 -4.462005e-01 -8.949320e-01
+   outer loop
+     vertex -1.351996e+02 -8.432039e+00 -1.959233e+01
+     vertex -1.254542e+02 -1.645613e+01 -1.557721e+01
+     vertex -1.351996e+02 -1.057273e+01 -1.852501e+01
+   endloop
+ endfacet
+ facet normal -1.675045e-01 -4.398967e-01 -8.822886e-01
+   outer loop
+     vertex -1.351996e+02 -8.432039e+00 -1.959233e+01
+     vertex -1.351996e+02 -1.057273e+01 -1.852501e+01
+     vertex -1.384481e+02 -7.078382e+00 -1.965051e+01
+   endloop
+ endfacet
+ facet normal -1.387268e-01 -9.474205e-01 -2.883561e-01
+   outer loop
+     vertex -1.059634e+02 -2.411932e+01 -7.701429e+00
+     vertex -1.157088e+02 -2.330540e+01 -5.687158e+00
+     vertex -1.157088e+02 -2.252207e+01 -8.260852e+00
+   endloop
+ endfacet
+ facet normal -1.189333e-01 -9.762781e-01 -1.809308e-01
+   outer loop
+     vertex -1.059634e+02 -2.411932e+01 -7.701429e+00
+     vertex -1.157088e+02 -2.379563e+01 -3.041940e+00
+     vertex -1.157088e+02 -2.330540e+01 -5.687158e+00
+   endloop
+ endfacet
+ facet normal -1.382475e-01 -9.092379e-01 -3.926502e-01
+   outer loop
+     vertex -1.059634e+02 -2.347632e+01 -9.482387e+00
+     vertex -1.157088e+02 -2.252207e+01 -8.260852e+00
+     vertex -1.157088e+02 -2.145550e+01 -1.073066e+01
+   endloop
+ endfacet
+ facet normal -1.334597e-01 -9.321618e-01 -3.365455e-01
+   outer loop
+     vertex -1.059634e+02 -2.347632e+01 -9.482387e+00
+     vertex -1.059634e+02 -2.411932e+01 -7.701429e+00
+     vertex -1.157088e+02 -2.252207e+01 -8.260852e+00
+   endloop
+ endfacet
+ facet normal -1.312896e-01 -9.324344e-01 -3.366439e-01
+   outer loop
+     vertex -1.010907e+02 -2.393240e+01 -1.011947e+01
+     vertex -1.059634e+02 -2.411932e+01 -7.701429e+00
+     vertex -1.059634e+02 -2.347632e+01 -9.482387e+00
+   endloop
+ endfacet
+ facet normal -8.615185e-02 -9.648723e-01 -2.481921e-01
+   outer loop
+     vertex -1.010907e+02 -2.393240e+01 -1.011947e+01
+     vertex -9.621794e+01 -2.661241e+01 -1.392094e+00
+     vertex -1.059634e+02 -2.411932e+01 -7.701429e+00
+   endloop
+ endfacet
+ facet normal -1.380935e-01 -9.010454e-01 -4.111537e-01
+   outer loop
+     vertex -1.010907e+02 -2.332733e+01 -1.144549e+01
+     vertex -1.010907e+02 -2.393240e+01 -1.011947e+01
+     vertex -1.059634e+02 -2.347632e+01 -9.482387e+00
+   endloop
+ endfacet
+ facet normal -1.584462e-01 -8.738727e-01 -4.596099e-01
+   outer loop
+     vertex -1.010907e+02 -2.264886e+01 -1.273550e+01
+     vertex -1.010907e+02 -2.332733e+01 -1.144549e+01
+     vertex -1.059634e+02 -2.347632e+01 -9.482387e+00
+   endloop
+ endfacet
+ facet normal -1.789781e-01 -7.368305e-01  6.519568e-01
+   outer loop
+     vertex -7.185439e+01 -2.587178e+01  1.513417e+01
+     vertex -7.185439e+01 -1.817201e+01  2.383632e+01
+     vertex -8.159981e+01 -1.569453e+01  2.396096e+01
+   endloop
+ endfacet
+ facet normal -8.653701e-02 -6.987503e-01  7.101122e-01
+   outer loop
+     vertex -7.185439e+01 -2.587178e+01  1.513417e+01
+     vertex -8.159981e+01 -1.569453e+01  2.396096e+01
+     vertex -8.647252e+01 -2.238647e+01  1.678229e+01
+   endloop
+ endfacet
+ facet normal -1.292243e-01 -5.647860e-01 -8.150570e-01
+   outer loop
+     vertex -1.157088e+02 -9.183279e+00 -2.216197e+01
+     vertex -1.254542e+02 -1.645613e+01 -1.557721e+01
+     vertex -1.351996e+02 -8.432039e+00 -1.959233e+01
+   endloop
+ endfacet
+ facet normal -1.356797e-01 -2.036898e-01 -9.695883e-01
+   outer loop
+     vertex -1.157088e+02 -9.183279e+00 -2.216197e+01
+     vertex -1.351996e+02 -8.432039e+00 -1.959233e+01
+     vertex -1.449450e+02  4.657024e-05 -2.000000e+01
+   endloop
+ endfacet
+ facet normal -1.733043e-01 -6.456152e-01  7.437383e-01
+   outer loop
+     vertex -6.102615e+01 -2.387465e+01  2.047309e+01
+     vertex -5.723626e+01 -1.820555e+01  2.627736e+01
+     vertex -6.698168e+01 -1.524675e+01  2.657495e+01
+   endloop
+ endfacet
+ facet normal -7.661907e-02 -6.104309e-01  7.883551e-01
+   outer loop
+     vertex -6.102615e+01 -2.387465e+01  2.047309e+01
+     vertex -6.698168e+01 -1.524675e+01  2.657495e+01
+     vertex -7.185439e+01 -1.817201e+01  2.383632e+01
+   endloop
+ endfacet
+ facet normal -1.620032e-01 -7.390302e-01  6.539031e-01
+   outer loop
+     vertex -6.292109e+01 -2.607707e+01  1.711535e+01
+     vertex -7.185439e+01 -1.817201e+01  2.383632e+01
+     vertex -7.185439e+01 -2.587178e+01  1.513417e+01
+   endloop
+ endfacet
+ facet normal -2.087006e-01 -7.595870e-01  6.160128e-01
+   outer loop
+     vertex -6.292109e+01 -2.607707e+01  1.711535e+01
+     vertex -6.102615e+01 -2.387465e+01  2.047309e+01
+     vertex -7.185439e+01 -1.817201e+01  2.383632e+01
+   endloop
+ endfacet
+ facet normal -1.297486e-01 -8.585262e-01  4.960827e-01
+   outer loop
+     vertex -6.454533e+01 -2.758002e+01  1.408952e+01
+     vertex -6.292109e+01 -2.607707e+01  1.711535e+01
+     vertex -7.185439e+01 -2.587178e+01  1.513417e+01
+   endloop
+ endfacet
+ facet normal -1.507166e-01 -8.978560e-01  4.136895e-01
+   outer loop
+     vertex -6.454533e+01 -2.758002e+01  1.408952e+01
+     vertex -7.185439e+01 -2.587178e+01  1.513417e+01
+     vertex -7.185439e+01 -2.831460e+01  9.832353e+00
+   endloop
+ endfacet
+ facet normal -9.868270e-02 -9.490737e-01  2.992003e-01
+   outer loop
+     vertex -6.698168e+01 -3.007061e+01  5.869353e+00
+     vertex -7.185439e+01 -2.831460e+01  9.832353e+00
+     vertex -7.185439e+01 -2.883422e+01  8.184103e+00
+   endloop
+ endfacet
+ facet normal -8.686266e-02 -9.459829e-01  3.123640e-01
+   outer loop
+     vertex -6.698168e+01 -3.007061e+01  5.869353e+00
+     vertex -6.454533e+01 -2.758002e+01  1.408952e+01
+     vertex -7.185439e+01 -2.831460e+01  9.832353e+00
+   endloop
+ endfacet
+ facet normal -1.402758e-01 -7.897464e-01  5.971795e-01
+   outer loop
+     vertex -5.561202e+01 -2.650232e+01  1.826987e+01
+     vertex -6.102615e+01 -2.387465e+01  2.047309e+01
+     vertex -6.292109e+01 -2.607707e+01  1.711535e+01
+   endloop
+ endfacet
+ facet normal -4.849615e-02 -6.985341e-01  7.139316e-01
+   outer loop
+     vertex -5.561202e+01 -2.650232e+01  1.826987e+01
+     vertex -5.723626e+01 -1.820555e+01  2.627736e+01
+     vertex -6.102615e+01 -2.387465e+01  2.047309e+01
+   endloop
+ endfacet
+ facet normal -2.259247e-01 -9.586461e-01  1.730769e-01
+   outer loop
+     vertex -6.102615e+01 -2.902161e+01  1.211992e+01
+     vertex -5.723626e+01 -3.195770e+01  8.044641e-01
+     vertex -5.398779e+01 -3.146503e+01  7.773659e+00
+   endloop
+ endfacet
+ facet normal -1.248543e-01 -8.747327e-01  4.682457e-01
+   outer loop
+     vertex -6.102615e+01 -2.902161e+01  1.211992e+01
+     vertex -5.561202e+01 -2.650232e+01  1.826987e+01
+     vertex -6.292109e+01 -2.607707e+01  1.711535e+01
+   endloop
+ endfacet
+ facet normal -8.831421e-02 -8.724069e-01  4.807357e-01
+   outer loop
+     vertex -6.102615e+01 -2.902161e+01  1.211992e+01
+     vertex -6.292109e+01 -2.607707e+01  1.711535e+01
+     vertex -6.454533e+01 -2.758002e+01  1.408952e+01
+   endloop
+ endfacet
+ facet normal -6.910951e-02 -9.710152e-01  2.288085e-01
+   outer loop
+     vertex -6.102615e+01 -2.902161e+01  1.211992e+01
+     vertex -6.698168e+01 -3.007061e+01  5.869353e+00
+     vertex -5.723626e+01 -3.195770e+01  8.044641e-01
+   endloop
+ endfacet
+ facet normal -1.899639e-01 -9.225689e-01  3.358279e-01
+   outer loop
+     vertex -6.102615e+01 -2.902161e+01  1.211992e+01
+     vertex -6.454533e+01 -2.758002e+01  1.408952e+01
+     vertex -6.698168e+01 -3.007061e+01  5.869353e+00
+   endloop
+ endfacet
+ facet normal -5.528366e-02 -9.059394e-01  4.197827e-01
+   outer loop
+     vertex -6.102615e+01 -2.902161e+01  1.211992e+01
+     vertex -5.398779e+01 -3.146503e+01  7.773659e+00
+     vertex -5.561202e+01 -2.650232e+01  1.826987e+01
+   endloop
+ endfacet
+ facet normal -1.784789e-01 -7.011686e-01  6.902956e-01
+   outer loop
+     vertex -5.290496e+01 -2.635059e+01  1.912391e+01
+     vertex -5.723626e+01 -1.820555e+01  2.627736e+01
+     vertex -5.561202e+01 -2.650232e+01  1.826987e+01
+   endloop
+ endfacet
+ facet normal -6.773341e-02 -9.071861e-01  4.152416e-01
+   outer loop
+     vertex -5.290496e+01 -2.635059e+01  1.912391e+01
+     vertex -5.398779e+01 -3.146503e+01  7.773659e+00
+     vertex -4.749084e+01 -2.596888e+01  2.084098e+01
+   endloop
+ endfacet
+ facet normal -1.632619e-01 -7.197329e-01  6.747815e-01
+   outer loop
+     vertex -5.290496e+01 -2.635059e+01  1.912391e+01
+     vertex -4.749084e+01 -2.596888e+01  2.084098e+01
+     vertex -4.749084e+01 -2.247016e+01  2.457277e+01
+   endloop
+ endfacet
+ facet normal -1.873659e-01 -7.025677e-01  6.865076e-01
+   outer loop
+     vertex -5.290496e+01 -2.635059e+01  1.912391e+01
+     vertex -4.749084e+01 -2.247016e+01  2.457277e+01
+     vertex -5.723626e+01 -1.820555e+01  2.627736e+01
+   endloop
+ endfacet
+ facet normal -8.042480e-02 -9.058665e-01  4.158577e-01
+   outer loop
+     vertex -5.290496e+01 -2.635059e+01  1.912391e+01
+     vertex -5.561202e+01 -2.650232e+01  1.826987e+01
+     vertex -5.398779e+01 -3.146503e+01  7.773659e+00
+   endloop
+ endfacet
+ facet normal -1.442799e-01 -9.554683e-01 -2.574171e-01
+   outer loop
+     vertex -6.698168e+01 -2.867121e+01 -1.080059e+01
+     vertex -5.723626e+01 -3.033661e+01 -1.008128e+01
+     vertex -5.723626e+01 -3.129520e+01 -6.523230e+00
+   endloop
+ endfacet
+ facet normal -1.331803e-01 -9.287540e-01 -3.459466e-01
+   outer loop
+     vertex -6.698168e+01 -2.867121e+01 -1.080059e+01
+     vertex -5.723626e+01 -2.953937e+01 -1.222161e+01
+     vertex -5.723626e+01 -3.033661e+01 -1.008128e+01
+   endloop
+ endfacet
+ facet normal -1.030203e-01 -8.884044e-01 -4.473528e-01
+   outer loop
+     vertex -6.698168e+01 -2.867121e+01 -1.080059e+01
+     vertex -7.185439e+01 -2.714825e+01 -1.270293e+01
+     vertex -7.185439e+01 -2.637100e+01 -1.424649e+01
+   endloop
+ endfacet
+ facet normal -5.467736e-02 -8.644559e-01 -4.997263e-01
+   outer loop
+     vertex -7.185439e+01 -2.550607e+01 -1.574270e+01
+     vertex -6.698168e+01 -2.867121e+01 -1.080059e+01
+     vertex -7.185439e+01 -2.637100e+01 -1.424649e+01
+   endloop
+ endfacet
+ facet normal -9.468530e-02 -9.846489e-01 -1.466331e-01
+   outer loop
+     vertex -5.073931e+01 -3.285334e+01 -2.555007e-01
+     vertex -5.723626e+01 -3.183797e+01 -2.878506e+00
+     vertex -5.723626e+01 -3.129520e+01 -6.523230e+00
+   endloop
+ endfacet
+ facet normal -1.163188e-01 -9.853915e-01 -1.243931e-01
+   outer loop
+     vertex -5.073931e+01 -3.285334e+01 -2.555007e-01
+     vertex -5.723626e+01 -3.129520e+01 -6.523230e+00
+     vertex -4.749084e+01 -3.219754e+01 -8.488081e+00
+   endloop
+ endfacet
+ facet normal -1.156994e-01 -9.855639e-01  1.236017e-01
+   outer loop
+     vertex -5.073931e+01 -3.285334e+01 -2.555007e-01
+     vertex -5.398779e+01 -3.146503e+01  7.773659e+00
+     vertex -5.723626e+01 -3.195770e+01  8.044641e-01
+   endloop
+ endfacet
+ facet normal -1.907503e-01 -9.591072e-01  2.091118e-01
+   outer loop
+     vertex -5.073931e+01 -3.285334e+01 -2.555007e-01
+     vertex -3.774542e+01 -3.420145e+01  5.414234e+00
+     vertex -3.774542e+01 -3.335117e+01  9.314096e+00
+   endloop
+ endfacet
+ facet normal -1.416408e-01 -9.893954e-01 -3.216594e-02
+   outer loop
+     vertex -5.073931e+01 -3.285334e+01 -2.555007e-01
+     vertex -5.723626e+01 -3.195770e+01  8.044641e-01
+     vertex -5.723626e+01 -3.183797e+01 -2.878506e+00
+   endloop
+ endfacet
+ facet normal -1.256930e-01 -9.848535e-01  1.194356e-01
+   outer loop
+     vertex -5.073931e+01 -3.285334e+01 -2.555007e-01
+     vertex -3.774542e+01 -3.335117e+01  9.314096e+00
+     vertex -5.398779e+01 -3.146503e+01  7.773659e+00
+   endloop
+ endfacet
+ facet normal -1.160192e-01 -9.854412e-01 -1.242788e-01
+   outer loop
+     vertex -5.073931e+01 -3.285334e+01 -2.555007e-01
+     vertex -4.749084e+01 -3.219754e+01 -8.488081e+00
+     vertex -3.774542e+01 -3.459729e+01  1.442433e+00
+   endloop
+ endfacet
+ facet normal -1.449627e-01 -9.845596e-01  9.812387e-02
+   outer loop
+     vertex -5.073931e+01 -3.285334e+01 -2.555007e-01
+     vertex -3.774542e+01 -3.459729e+01  1.442433e+00
+     vertex -3.774542e+01 -3.420145e+01  5.414234e+00
+   endloop
+ endfacet
+ facet normal -1.340603e-01 -1.293913e-01 -9.824896e-01
+   outer loop
+     vertex -8.647252e+01 -7.243800e+00 -2.702456e+01
+     vertex -1.449450e+02  4.657024e-05 -2.000000e+01
+     vertex -2.800000e+01  2.050521e-05 -3.595710e+01
+   endloop
+ endfacet
+ facet normal -1.444417e-01 -2.334713e-01 -9.615757e-01
+   outer loop
+     vertex -8.647252e+01 -7.243800e+00 -2.702456e+01
+     vertex -1.157088e+02 -9.183279e+00 -2.216197e+01
+     vertex -1.449450e+02  4.657024e-05 -2.000000e+01
+   endloop
+ endfacet
+ facet normal -1.206242e-01 -2.199980e-01 -9.680138e-01
+   outer loop
+     vertex -5.723626e+01 -1.223753e+01 -2.953277e+01
+     vertex -8.647252e+01 -7.243800e+00 -2.702456e+01
+     vertex -2.800000e+01  2.050521e-05 -3.595710e+01
+   endloop
+ endfacet
+ facet normal -1.048746e-01 -6.856015e-01 -7.203831e-01
+   outer loop
+     vertex -3.774542e+01 -1.907492e+01 -2.889983e+01
+     vertex -2.800000e+01 -2.981907e+01 -2.009318e+01
+     vertex -4.749084e+01 -2.568388e+01 -2.119121e+01
+   endloop
+ endfacet
+ facet normal -1.421904e-01 -6.554640e-01 -7.417202e-01
+   outer loop
+     vertex -3.774542e+01 -1.907492e+01 -2.889983e+01
+     vertex -4.749084e+01 -2.568388e+01 -2.119121e+01
+     vertex -5.398779e+01 -1.709365e+01 -2.753698e+01
+   endloop
+ endfacet
+ facet normal -2.420315e-01 -7.368994e-01 -6.311894e-01
+   outer loop
+     vertex -3.774542e+01 -1.907492e+01 -2.889983e+01
+     vertex -2.800000e+01 -2.443546e+01 -2.637844e+01
+     vertex -2.800000e+01 -2.981907e+01 -2.009318e+01
+   endloop
+ endfacet
+ facet normal -1.339330e-01 -5.160056e-01 -8.460498e-01
+   outer loop
+     vertex -3.774542e+01 -1.696276e+01 -3.018804e+01
+     vertex -3.774542e+01 -1.907492e+01 -2.889983e+01
+     vertex -5.398779e+01 -1.709365e+01 -2.753698e+01
+   endloop
+ endfacet
+ facet normal -1.193798e-01 -5.919503e-01 -7.970843e-01
+   outer loop
+     vertex -3.449695e+01 -1.866177e+01 -2.969318e+01
+     vertex -2.800000e+01 -2.443546e+01 -2.637844e+01
+     vertex -3.774542e+01 -1.907492e+01 -2.889983e+01
+   endloop
+ endfacet
+ facet normal -1.408603e-01 -5.155052e-01 -8.452294e-01
+   outer loop
+     vertex -3.449695e+01 -1.866177e+01 -2.969318e+01
+     vertex -3.774542e+01 -1.907492e+01 -2.889983e+01
+     vertex -3.774542e+01 -1.696276e+01 -3.018804e+01
+   endloop
+ endfacet
+ facet normal -1.124652e-01 -5.868879e-01 -8.018193e-01
+   outer loop
+     vertex -3.449695e+01 -1.866177e+01 -2.969318e+01
+     vertex -2.800000e+01 -1.775744e+01 -3.126638e+01
+     vertex -2.800000e+01 -2.443546e+01 -2.637844e+01
+   endloop
+ endfacet
+ facet normal -1.397124e-01 -4.549230e-01 -8.795030e-01
+   outer loop
+     vertex -3.774542e+01 -1.476402e+01 -3.132214e+01
+     vertex -5.398779e+01 -1.709365e+01 -2.753698e+01
+     vertex -5.723626e+01 -1.223753e+01 -2.953277e+01
+   endloop
+ endfacet
+ facet normal -1.399734e-01 -4.538972e-01 -8.799914e-01
+   outer loop
+     vertex -3.774542e+01 -1.476402e+01 -3.132214e+01
+     vertex -3.774542e+01 -1.696276e+01 -3.018804e+01
+     vertex -5.398779e+01 -1.709365e+01 -2.753698e+01
+   endloop
+ endfacet
+ facet normal -1.335679e-01 -4.543026e-01 -8.807774e-01
+   outer loop
+     vertex -3.449695e+01 -1.482911e+01 -3.178119e+01
+     vertex -3.774542e+01 -1.696276e+01 -3.018804e+01
+     vertex -3.774542e+01 -1.476402e+01 -3.132214e+01
+   endloop
+ endfacet
+ facet normal -1.156616e-01 -4.751945e-01 -8.722457e-01
+   outer loop
+     vertex -3.449695e+01 -1.482911e+01 -3.178119e+01
+     vertex -3.449695e+01 -1.866177e+01 -2.969318e+01
+     vertex -3.774542e+01 -1.696276e+01 -3.018804e+01
+   endloop
+ endfacet
+ facet normal -1.445126e-01 -4.733834e-01 -8.689213e-01
+   outer loop
+     vertex -3.449695e+01 -1.482911e+01 -3.178119e+01
+     vertex -2.800000e+01 -1.775744e+01 -3.126638e+01
+     vertex -3.449695e+01 -1.866177e+01 -2.969318e+01
+   endloop
+ endfacet
+ facet normal -1.025188e-01 -3.884461e-01 -9.157508e-01
+   outer loop
+     vertex -3.449695e+01 -1.482911e+01 -3.178119e+01
+     vertex -2.800000e+01 -1.013878e+01 -3.449809e+01
+     vertex -2.800000e+01 -1.775744e+01 -3.126638e+01
+   endloop
+ endfacet
+ facet normal -1.473510e-01 -1.603393e-01 -9.760015e-01
+   outer loop
+     vertex -3.449695e+01 -1.173825e+01 -3.304785e+01
+     vertex -5.723626e+01 -1.223753e+01 -2.953277e+01
+     vertex -2.800000e+01  2.050521e-05 -3.595710e+01
+   endloop
+ endfacet
+ facet normal -1.332190e-01 -3.792144e-01 -9.156687e-01
+   outer loop
+     vertex -3.449695e+01 -1.173825e+01 -3.304785e+01
+     vertex -3.774542e+01 -1.476402e+01 -3.132214e+01
+     vertex -5.723626e+01 -1.223753e+01 -2.953277e+01
+   endloop
+ endfacet
+ facet normal -1.370511e-01 -3.756219e-01 -9.165834e-01
+   outer loop
+     vertex -3.449695e+01 -1.173825e+01 -3.304785e+01
+     vertex -3.449695e+01 -1.482911e+01 -3.178119e+01
+     vertex -3.774542e+01 -1.476402e+01 -3.132214e+01
+   endloop
+ endfacet
+ facet normal -1.124749e-01 -3.767939e-01 -9.194432e-01
+   outer loop
+     vertex -3.449695e+01 -1.173825e+01 -3.304785e+01
+     vertex -2.800000e+01 -1.013878e+01 -3.449809e+01
+     vertex -3.449695e+01 -1.482911e+01 -3.178119e+01
+   endloop
+ endfacet
+ facet normal -1.635032e-01 -2.098828e-01 -9.639585e-01
+   outer loop
+     vertex -3.449695e+01 -1.173825e+01 -3.304785e+01
+     vertex -2.800000e+01 -5.121597e+00 -3.559048e+01
+     vertex -2.800000e+01 -1.013878e+01 -3.449809e+01
+   endloop
+ endfacet
+ facet normal -3.027377e-01 -6.804987e-02 -9.506414e-01
+   outer loop
+     vertex -3.449695e+01 -1.173825e+01 -3.304785e+01
+     vertex -2.800000e+01  2.050521e-05 -3.595710e+01
+     vertex -2.800000e+01 -5.121597e+00 -3.559048e+01
+   endloop
+ endfacet
+ facet normal -1.135097e-01 -9.789891e-01 -1.693987e-01
+   outer loop
+     vertex -1.059634e+02 -2.530474e+01 -8.506302e-01
+     vertex -1.157088e+02 -2.379563e+01 -3.041940e+00
+     vertex -1.059634e+02 -2.411932e+01 -7.701429e+00
+   endloop
+ endfacet
+ facet normal -1.112089e-01 -9.884138e-01  1.032993e-01
+   outer loop
+     vertex -1.059634e+02 -2.530474e+01 -8.506302e-01
+     vertex -1.059634e+02 -2.458206e+01  6.064310e+00
+     vertex -1.157088e+02 -2.387590e+01  2.329518e+00
+   endloop
+ endfacet
+ facet normal -6.830519e-02 -9.922603e-01  1.037013e-01
+   outer loop
+     vertex -1.059634e+02 -2.530474e+01 -8.506302e-01
+     vertex -1.010907e+02 -2.471208e+01  8.029756e+00
+     vertex -1.059634e+02 -2.458206e+01  6.064310e+00
+   endloop
+ endfacet
+ facet normal -1.371919e-01 -9.880457e-01 -7.031391e-02
+   outer loop
+     vertex -1.059634e+02 -2.530474e+01 -8.506302e-01
+     vertex -1.157088e+02 -2.398660e+01 -3.584649e-01
+     vertex -1.157088e+02 -2.379563e+01 -3.041940e+00
+   endloop
+ endfacet
+ facet normal -1.244803e-01 -9.831435e-01  1.339164e-01
+   outer loop
+     vertex -1.059634e+02 -2.530474e+01 -8.506302e-01
+     vertex -9.621794e+01 -2.661241e+01 -1.392094e+00
+     vertex -1.010907e+02 -2.471208e+01  8.029756e+00
+   endloop
+ endfacet
+ facet normal -1.402898e-01 -9.756128e-01 -1.688145e-01
+   outer loop
+     vertex -1.059634e+02 -2.530474e+01 -8.506302e-01
+     vertex -1.059634e+02 -2.411932e+01 -7.701429e+00
+     vertex -9.621794e+01 -2.661241e+01 -1.392094e+00
+   endloop
+ endfacet
+ facet normal -1.319026e-01 -9.904232e-01  4.078719e-02
+   outer loop
+     vertex -1.059634e+02 -2.530474e+01 -8.506302e-01
+     vertex -1.157088e+02 -2.387590e+01  2.329518e+00
+     vertex -1.157088e+02 -2.398660e+01 -3.584649e-01
+   endloop
+ endfacet
+ facet normal -1.092561e-01 -8.918276e-01  4.389836e-01
+   outer loop
+     vertex -9.134523e+01 -2.612972e+01  7.954533e+00
+     vertex -1.010907e+02 -2.222560e+01  1.346055e+01
+     vertex -1.010907e+02 -2.422295e+01  9.402783e+00
+   endloop
+ endfacet
+ facet normal -1.332427e-01 -9.336120e-01  3.325885e-01
+   outer loop
+     vertex -9.134523e+01 -2.612972e+01  7.954533e+00
+     vertex -1.010907e+02 -2.422295e+01  9.402783e+00
+     vertex -1.010907e+02 -2.471208e+01  8.029756e+00
+   endloop
+ endfacet
+ facet normal -1.418862e-01 -9.819991e-01  1.246838e-01
+   outer loop
+     vertex -9.134523e+01 -2.612972e+01  7.954533e+00
+     vertex -1.010907e+02 -2.471208e+01  8.029756e+00
+     vertex -9.621794e+01 -2.661241e+01 -1.392094e+00
+   endloop
+ endfacet
+ facet normal -1.240387e-01 -9.855252e-01  1.155614e-01
+   outer loop
+     vertex -9.134523e+01 -2.612972e+01  7.954533e+00
+     vertex -9.621794e+01 -2.661241e+01 -1.392094e+00
+     vertex -8.647252e+01 -2.790822e+01 -1.982627e+00
+   endloop
+ endfacet
+ facet normal -1.094936e-01 -8.919594e-01  4.386566e-01
+   outer loop
+     vertex -9.134523e+01 -2.612972e+01  7.954533e+00
+     vertex -8.647252e+01 -2.238647e+01  1.678229e+01
+     vertex -1.010907e+02 -2.222560e+01  1.346055e+01
+   endloop
+ endfacet
+ facet normal -1.636131e-01 -5.325997e-01 -8.304025e-01
+   outer loop
+     vertex -1.189573e+02 -1.640644e+01 -1.688917e+01
+     vertex -1.254542e+02 -1.645613e+01 -1.557721e+01
+     vertex -1.157088e+02 -9.183279e+00 -2.216197e+01
+   endloop
+ endfacet
+ facet normal -1.206514e-01 -7.699128e-01 -6.266399e-01
+   outer loop
+     vertex -1.189573e+02 -1.640644e+01 -1.688917e+01
+     vertex -1.254542e+02 -1.859405e+01 -1.295048e+01
+     vertex -1.254542e+02 -1.645613e+01 -1.557721e+01
+   endloop
+ endfacet
+ facet normal -9.645232e-02 -7.940618e-01 -6.001356e-01
+   outer loop
+     vertex -1.189573e+02 -1.640644e+01 -1.688917e+01
+     vertex -1.157088e+02 -2.145550e+01 -1.073066e+01
+     vertex -1.254542e+02 -1.859405e+01 -1.295048e+01
+   endloop
+ endfacet
+ facet normal -1.423441e-01 -9.840897e-01  1.063283e-01
+   outer loop
+     vertex -8.647252e+01 -2.684063e+01  7.898096e+00
+     vertex -9.134523e+01 -2.612972e+01  7.954533e+00
+     vertex -8.647252e+01 -2.790822e+01 -1.982627e+00
+   endloop
+ endfacet
+ facet normal -1.242616e-01 -8.870127e-01  4.447107e-01
+   outer loop
+     vertex -8.647252e+01 -2.684063e+01  7.898096e+00
+     vertex -8.647252e+01 -2.238647e+01  1.678229e+01
+     vertex -9.134523e+01 -2.612972e+01  7.954533e+00
+   endloop
+ endfacet
+ facet normal -1.082226e-01 -7.960126e-01 -5.955265e-01
+   outer loop
+     vertex -1.157088e+02 -1.635091e+01 -1.755372e+01
+     vertex -1.157088e+02 -2.145550e+01 -1.073066e+01
+     vertex -1.189573e+02 -1.640644e+01 -1.688917e+01
+   endloop
+ endfacet
+ facet normal -1.607166e-01 -5.337677e-01 -8.302181e-01
+   outer loop
+     vertex -1.157088e+02 -1.635091e+01 -1.755372e+01
+     vertex -1.189573e+02 -1.640644e+01 -1.688917e+01
+     vertex -1.157088e+02 -9.183279e+00 -2.216197e+01
+   endloop
+ endfacet
+ facet normal -1.053771e-01 -8.384556e-01 -5.346848e-01
+   outer loop
+     vertex -1.108361e+02 -1.856784e+01 -1.621921e+01
+     vertex -1.059634e+02 -2.347632e+01 -9.482387e+00
+     vertex -1.157088e+02 -2.145550e+01 -1.073066e+01
+   endloop
+ endfacet
+ facet normal -1.820666e-01 -8.527215e-01 -4.896098e-01
+   outer loop
+     vertex -1.108361e+02 -1.856784e+01 -1.621921e+01
+     vertex -1.010907e+02 -2.264886e+01 -1.273550e+01
+     vertex -1.059634e+02 -2.347632e+01 -9.482387e+00
+   endloop
+ endfacet
+ facet normal -1.963394e-01 -7.851304e-01 -5.873850e-01
+   outer loop
+     vertex -1.108361e+02 -1.856784e+01 -1.621921e+01
+     vertex -1.157088e+02 -2.145550e+01 -1.073066e+01
+     vertex -1.157088e+02 -1.635091e+01 -1.755372e+01
+   endloop
+ endfacet
+ facet normal -1.363147e-01 -9.849331e-01  1.064194e-01
+   outer loop
+     vertex -8.159981e+01 -2.750426e+01  7.997611e+00
+     vertex -8.647252e+01 -2.684063e+01  7.898096e+00
+     vertex -8.647252e+01 -2.790822e+01 -1.982627e+00
+   endloop
+ endfacet
+ facet normal -1.297947e-01 -8.863792e-01  4.443931e-01
+   outer loop
+     vertex -8.159981e+01 -2.750426e+01  7.997611e+00
+     vertex -8.647252e+01 -2.238647e+01  1.678229e+01
+     vertex -8.647252e+01 -2.684063e+01  7.898096e+00
+   endloop
+ endfacet
+ facet normal -1.346717e-01 -9.450407e-01  2.979288e-01
+   outer loop
+     vertex -8.159981e+01 -2.750426e+01  7.997611e+00
+     vertex -7.185439e+01 -2.883422e+01  8.184103e+00
+     vertex -7.185439e+01 -2.831460e+01  9.832353e+00
+   endloop
+ endfacet
+ facet normal -1.364184e-01 -9.855835e-01  1.000760e-01
+   outer loop
+     vertex -8.159981e+01 -2.750426e+01  7.997611e+00
+     vertex -7.672710e+01 -2.922071e+01 -2.264345e+00
+     vertex -7.185439e+01 -2.883422e+01  8.184103e+00
+   endloop
+ endfacet
+ facet normal -1.298252e-01 -9.861412e-01  1.032999e-01
+   outer loop
+     vertex -8.159981e+01 -2.750426e+01  7.997611e+00
+     vertex -8.647252e+01 -2.790822e+01 -1.982627e+00
+     vertex -7.672710e+01 -2.922071e+01 -2.264345e+00
+   endloop
+ endfacet
+ facet normal -1.638494e-01 -8.892098e-01  4.271526e-01
+   outer loop
+     vertex -8.159981e+01 -2.750426e+01  7.997611e+00
+     vertex -7.185439e+01 -2.587178e+01  1.513417e+01
+     vertex -8.647252e+01 -2.238647e+01  1.678229e+01
+   endloop
+ endfacet
+ facet normal -1.524999e-01 -8.976076e-01  4.135751e-01
+   outer loop
+     vertex -8.159981e+01 -2.750426e+01  7.997611e+00
+     vertex -7.185439e+01 -2.831460e+01  9.832353e+00
+     vertex -7.185439e+01 -2.587178e+01  1.513417e+01
+   endloop
+ endfacet
+ facet normal -1.464137e-01 -5.349699e-01 -8.320879e-01
+   outer loop
+     vertex -1.083997e+02 -1.658250e+01 -1.869092e+01
+     vertex -1.157088e+02 -1.635091e+01 -1.755372e+01
+     vertex -1.157088e+02 -9.183279e+00 -2.216197e+01
+   endloop
+ endfacet
+ facet normal -1.306542e-01 -7.061072e-01 -6.959469e-01
+   outer loop
+     vertex -1.083997e+02 -1.658250e+01 -1.869092e+01
+     vertex -1.108361e+02 -1.856784e+01 -1.621921e+01
+     vertex -1.157088e+02 -1.635091e+01 -1.755372e+01
+   endloop
+ endfacet
+ facet normal -7.219063e-02 -7.416618e-01 -6.668780e-01
+   outer loop
+     vertex -1.083997e+02 -1.658250e+01 -1.869092e+01
+     vertex -1.010907e+02 -2.264886e+01 -1.273550e+01
+     vertex -1.108361e+02 -1.856784e+01 -1.621921e+01
+   endloop
+ endfacet
+ facet normal -1.242595e-01 -9.658820e-01 -2.272257e-01
+   outer loop
+     vertex -9.134523e+01 -2.495432e+01 -1.110489e+01
+     vertex -9.621794e+01 -2.661241e+01 -1.392094e+00
+     vertex -1.010907e+02 -2.393240e+01 -1.011947e+01
+   endloop
+ endfacet
+ facet normal -1.360967e-01 -9.012969e-01 -4.112684e-01
+   outer loop
+     vertex -9.134523e+01 -2.495432e+01 -1.110489e+01
+     vertex -1.010907e+02 -2.393240e+01 -1.011947e+01
+     vertex -1.010907e+02 -2.332733e+01 -1.144549e+01
+   endloop
+ endfacet
+ facet normal -1.303676e-01 -8.774998e-01 -4.615175e-01
+   outer loop
+     vertex -9.134523e+01 -2.495432e+01 -1.110489e+01
+     vertex -1.010907e+02 -2.332733e+01 -1.144549e+01
+     vertex -1.010907e+02 -2.264886e+01 -1.273550e+01
+   endloop
+ endfacet
+ facet normal -1.421054e-01 -9.614482e-01 -2.354218e-01
+   outer loop
+     vertex -9.134523e+01 -2.495432e+01 -1.110489e+01
+     vertex -8.647252e+01 -2.790822e+01 -1.982627e+00
+     vertex -9.621794e+01 -2.661241e+01 -1.392094e+00
+   endloop
+ endfacet
+ facet normal -1.423441e-01 -8.132380e-01 -5.642536e-01
+   outer loop
+     vertex -8.647252e+01 -2.545453e+01 -1.161320e+01
+     vertex -9.134523e+01 -2.495432e+01 -1.110489e+01
+     vertex -8.647252e+01 -1.978916e+01 -1.977849e+01
+   endloop
+ endfacet
+ facet normal -1.242616e-01 -9.615320e-01 -2.449803e-01
+   outer loop
+     vertex -8.647252e+01 -2.545453e+01 -1.161320e+01
+     vertex -8.647252e+01 -2.790822e+01 -1.982627e+00
+     vertex -9.134523e+01 -2.495432e+01 -1.110489e+01
+   endloop
+ endfacet
+ facet normal -1.215522e-01 -4.211497e-01 -8.988092e-01
+   outer loop
+     vertex -1.010907e+02 -1.404566e+01 -2.186054e+01
+     vertex -1.157088e+02 -9.183279e+00 -2.216197e+01
+     vertex -8.647252e+01 -7.243800e+00 -2.702456e+01
+   endloop
+ endfacet
+ facet normal -1.653756e-01 -5.480114e-01 -8.199600e-01
+   outer loop
+     vertex -1.010907e+02 -1.404566e+01 -2.186054e+01
+     vertex -1.083997e+02 -1.658250e+01 -1.869092e+01
+     vertex -1.157088e+02 -9.183279e+00 -2.216197e+01
+   endloop
+ endfacet
+ facet normal -4.490209e-02 -7.268718e-01 -6.853037e-01
+   outer loop
+     vertex -1.010907e+02 -1.404566e+01 -2.186054e+01
+     vertex -1.010907e+02 -2.264886e+01 -1.273550e+01
+     vertex -1.083997e+02 -1.658250e+01 -1.869092e+01
+   endloop
+ endfacet
+ facet normal -1.297947e-01 -9.608453e-01 -2.448053e-01
+   outer loop
+     vertex -8.159981e+01 -2.602116e+01 -1.197269e+01
+     vertex -8.647252e+01 -2.790822e+01 -1.982627e+00
+     vertex -8.647252e+01 -2.545453e+01 -1.161320e+01
+   endloop
+ endfacet
+ facet normal -1.363147e-01 -8.139350e-01 -5.647372e-01
+   outer loop
+     vertex -8.159981e+01 -2.602116e+01 -1.197269e+01
+     vertex -8.647252e+01 -2.545453e+01 -1.161320e+01
+     vertex -8.647252e+01 -1.978916e+01 -1.977849e+01
+   endloop
+ endfacet
+ facet normal -1.363428e-01 -9.591982e-01 -2.476881e-01
+   outer loop
+     vertex -8.159981e+01 -2.602116e+01 -1.197269e+01
+     vertex -7.672710e+01 -2.922071e+01 -2.264345e+00
+     vertex -8.647252e+01 -2.790822e+01 -1.982627e+00
+   endloop
+ endfacet
+ facet normal -1.297494e-01 -9.592482e-01 -2.510138e-01
+   outer loop
+     vertex -8.159981e+01 -2.602116e+01 -1.197269e+01
+     vertex -7.185439e+01 -2.714825e+01 -1.270293e+01
+     vertex -7.672710e+01 -2.922071e+01 -2.264345e+00
+   endloop
+ endfacet
+ facet normal -1.357291e-01 -8.848914e-01 -4.455838e-01
+   outer loop
+     vertex -8.159981e+01 -2.602116e+01 -1.197269e+01
+     vertex -7.185439e+01 -2.637100e+01 -1.424649e+01
+     vertex -7.185439e+01 -2.714825e+01 -1.270293e+01
+   endloop
+ endfacet
+ facet normal -1.462593e-01 -8.564409e-01 -4.950931e-01
+   outer loop
+     vertex -8.159981e+01 -2.602116e+01 -1.197269e+01
+     vertex -7.185439e+01 -2.550607e+01 -1.574270e+01
+     vertex -7.185439e+01 -2.637100e+01 -1.424649e+01
+   endloop
+ endfacet
+ facet normal -9.360281e-02 -4.665701e-01 -8.795174e-01
+   outer loop
+     vertex -9.378159e+01 -1.654740e+01 -2.131127e+01
+     vertex -1.010907e+02 -1.404566e+01 -2.186054e+01
+     vertex -8.647252e+01 -7.243800e+00 -2.702456e+01
+   endloop
+ endfacet
+ facet normal -1.937505e-01 -7.138182e-01 -6.729965e-01
+   outer loop
+     vertex -9.378159e+01 -1.654740e+01 -2.131127e+01
+     vertex -1.010907e+02 -2.264886e+01 -1.273550e+01
+     vertex -1.010907e+02 -1.404566e+01 -2.186054e+01
+   endloop
+ endfacet
+ facet normal -2.153011e-01 -7.811058e-01 -5.861050e-01
+   outer loop
+     vertex -9.134523e+01 -1.763849e+01 -2.085475e+01
+     vertex -8.647252e+01 -1.978916e+01 -1.977849e+01
+     vertex -9.134523e+01 -2.495432e+01 -1.110489e+01
+   endloop
+ endfacet
+ facet normal -8.845224e-02 -7.967294e-01 -5.978282e-01
+   outer loop
+     vertex -9.134523e+01 -1.763849e+01 -2.085475e+01
+     vertex -9.134523e+01 -2.495432e+01 -1.110489e+01
+     vertex -1.010907e+02 -2.264886e+01 -1.273550e+01
+   endloop
+ endfacet
+ facet normal -1.936150e-01 -7.139054e-01 -6.729431e-01
+   outer loop
+     vertex -9.134523e+01 -1.763849e+01 -2.085475e+01
+     vertex -1.010907e+02 -2.264886e+01 -1.273550e+01
+     vertex -9.378159e+01 -1.654740e+01 -2.131127e+01
+   endloop
+ endfacet
+ facet normal -1.296736e-01 -9.868032e-01  9.697561e-02
+   outer loop
+     vertex -6.698168e+01 -3.053068e+01 -2.562978e+00
+     vertex -7.185439e+01 -2.883422e+01  8.184103e+00
+     vertex -7.672710e+01 -2.922071e+01 -2.264345e+00
+   endloop
+ endfacet
+ facet normal -1.361694e-01 -9.798798e-01 -1.459229e-01
+   outer loop
+     vertex -6.698168e+01 -3.053068e+01 -2.562978e+00
+     vertex -5.723626e+01 -3.129520e+01 -6.523230e+00
+     vertex -5.723626e+01 -3.183797e+01 -2.878506e+00
+   endloop
+ endfacet
+ facet normal -1.339081e-01 -9.904705e-01 -3.220090e-02
+   outer loop
+     vertex -6.698168e+01 -3.053068e+01 -2.562978e+00
+     vertex -5.723626e+01 -3.183797e+01 -2.878506e+00
+     vertex -5.723626e+01 -3.195770e+01  8.044641e-01
+   endloop
+ endfacet
+ facet normal -2.138505e-01 -9.528914e-01 -2.150950e-01
+   outer loop
+     vertex -6.698168e+01 -3.053068e+01 -2.562978e+00
+     vertex -7.185439e+01 -2.714825e+01 -1.270293e+01
+     vertex -6.698168e+01 -2.867121e+01 -1.080059e+01
+   endloop
+ endfacet
+ facet normal -2.218146e-01 -9.736408e-01  5.312132e-02
+   outer loop
+     vertex -6.698168e+01 -3.053068e+01 -2.562978e+00
+     vertex -6.698168e+01 -3.007061e+01  5.869353e+00
+     vertex -7.185439e+01 -2.883422e+01  8.184103e+00
+   endloop
+ endfacet
+ facet normal -1.628346e-01 -9.851881e-01  5.375134e-02
+   outer loop
+     vertex -6.698168e+01 -3.053068e+01 -2.562978e+00
+     vertex -5.723626e+01 -3.195770e+01  8.044641e-01
+     vertex -6.698168e+01 -3.007061e+01  5.869353e+00
+   endloop
+ endfacet
+ facet normal -1.364940e-01 -9.575700e-01 -2.538290e-01
+   outer loop
+     vertex -6.698168e+01 -3.053068e+01 -2.562978e+00
+     vertex -7.672710e+01 -2.922071e+01 -2.264345e+00
+     vertex -7.185439e+01 -2.714825e+01 -1.270293e+01
+   endloop
+ endfacet
+ facet normal -1.637609e-01 -9.622887e-01 -2.172162e-01
+   outer loop
+     vertex -6.698168e+01 -3.053068e+01 -2.562978e+00
+     vertex -6.698168e+01 -2.867121e+01 -1.080059e+01
+     vertex -5.723626e+01 -3.129520e+01 -6.523230e+00
+   endloop
+ endfacet
+ facet normal -9.315956e-02 -6.062914e-01 -7.897671e-01
+   outer loop
+     vertex -8.647252e+01 -1.399362e+01 -2.422762e+01
+     vertex -8.647252e+01 -1.978916e+01 -1.977849e+01
+     vertex -9.134523e+01 -1.763849e+01 -2.085475e+01
+   endloop
+ endfacet
+ facet normal -2.286381e-01 -3.726677e-01 -8.993572e-01
+   outer loop
+     vertex -8.647252e+01 -1.399362e+01 -2.422762e+01
+     vertex -9.378159e+01 -1.654740e+01 -2.131127e+01
+     vertex -8.647252e+01 -7.243800e+00 -2.702456e+01
+   endloop
+ endfacet
+ facet normal -1.136589e-01 -5.886720e-01 -8.003417e-01
+   outer loop
+     vertex -8.647252e+01 -1.399362e+01 -2.422762e+01
+     vertex -9.134523e+01 -1.763849e+01 -2.085475e+01
+     vertex -9.378159e+01 -1.654740e+01 -2.131127e+01
+   endloop
+ endfacet
+ facet normal -1.793076e-01 -5.990705e-01 -7.803610e-01
+   outer loop
+     vertex -8.159981e+01 -1.819851e+01 -2.211923e+01
+     vertex -8.647252e+01 -1.978916e+01 -1.977849e+01
+     vertex -8.647252e+01 -1.399362e+01 -2.422762e+01
+   endloop
+ endfacet
+ facet normal -3.475844e-02 -7.914803e-01 -6.102055e-01
+   outer loop
+     vertex -8.159981e+01 -1.819851e+01 -2.211923e+01
+     vertex -8.159981e+01 -2.602116e+01 -1.197269e+01
+     vertex -8.647252e+01 -1.978916e+01 -1.977849e+01
+   endloop
+ endfacet
+ facet normal -1.907722e-01 -7.774140e-01 -5.993609e-01
+   outer loop
+     vertex -8.159981e+01 -1.819851e+01 -2.211923e+01
+     vertex -7.185439e+01 -2.550607e+01 -1.574270e+01
+     vertex -8.159981e+01 -2.602116e+01 -1.197269e+01
+   endloop
+ endfacet
+ facet normal -1.551084e-01 -5.805363e-01 -7.993241e-01
+   outer loop
+     vertex -7.916346e+01 -1.730082e+01 -2.324398e+01
+     vertex -8.159981e+01 -1.819851e+01 -2.211923e+01
+     vertex -8.647252e+01 -1.399362e+01 -2.422762e+01
+   endloop
+ endfacet
+ facet normal -4.882644e-02 -3.823511e-01 -9.227262e-01
+   outer loop
+     vertex -7.916346e+01 -1.730082e+01 -2.324398e+01
+     vertex -8.647252e+01 -1.399362e+01 -2.422762e+01
+     vertex -8.647252e+01 -7.243800e+00 -2.702456e+01
+   endloop
+ endfacet
+ facet normal -6.636795e-02 -7.048093e-01 -7.062855e-01
+   outer loop
+     vertex -7.916346e+01 -1.730082e+01 -2.324398e+01
+     vertex -7.185439e+01 -2.550607e+01 -1.574270e+01
+     vertex -8.159981e+01 -1.819851e+01 -2.211923e+01
+   endloop
+ endfacet
+ facet normal -1.481518e-01 -4.169410e-01 -8.967783e-01
+   outer loop
+     vertex -7.185439e+01 -1.585813e+01 -2.543446e+01
+     vertex -8.647252e+01 -7.243800e+00 -2.702456e+01
+     vertex -5.723626e+01 -1.223753e+01 -2.953277e+01
+   endloop
+ endfacet
+ facet normal -1.723978e-01 -4.539188e-01 -8.742063e-01
+   outer loop
+     vertex -7.185439e+01 -1.585813e+01 -2.543446e+01
+     vertex -7.916346e+01 -1.730082e+01 -2.324398e+01
+     vertex -8.647252e+01 -7.243800e+00 -2.702456e+01
+   endloop
+ endfacet
+ facet normal -7.136478e-02 -7.069002e-01 -7.037038e-01
+   outer loop
+     vertex -7.185439e+01 -1.585813e+01 -2.543446e+01
+     vertex -7.185439e+01 -2.550607e+01 -1.574270e+01
+     vertex -7.916346e+01 -1.730082e+01 -2.324398e+01
+   endloop
+ endfacet
+ facet normal -1.478208e-01 -8.600505e-01 -4.883258e-01
+   outer loop
+     vertex -6.102615e+01 -2.497041e+01 -1.912132e+01
+     vertex -5.723626e+01 -2.953937e+01 -1.222161e+01
+     vertex -6.698168e+01 -2.867121e+01 -1.080059e+01
+   endloop
+ endfacet
+ facet normal -1.012011e-01 -8.801009e-01 -4.638757e-01
+   outer loop
+     vertex -6.102615e+01 -2.497041e+01 -1.912132e+01
+     vertex -6.698168e+01 -2.867121e+01 -1.080059e+01
+     vertex -7.185439e+01 -2.550607e+01 -1.574270e+01
+   endloop
+ endfacet
+ facet normal -2.243558e-01 -6.906404e-01 -6.875175e-01
+   outer loop
+     vertex -6.454533e+01 -2.007759e+01 -2.358098e+01
+     vertex -7.185439e+01 -2.550607e+01 -1.574270e+01
+     vertex -7.185439e+01 -1.585813e+01 -2.543446e+01
+   endloop
+ endfacet
+ facet normal -1.710978e-01 -7.280864e-01 -6.637889e-01
+   outer loop
+     vertex -6.454533e+01 -2.007759e+01 -2.358098e+01
+     vertex -6.102615e+01 -2.497041e+01 -1.912132e+01
+     vertex -7.185439e+01 -2.550607e+01 -1.574270e+01
+   endloop
+ endfacet
+ facet normal -9.431895e-02 -8.531175e-01 -5.131223e-01
+   outer loop
+     vertex -5.561202e+01 -2.454137e+01 -2.082983e+01
+     vertex -5.723626e+01 -2.953937e+01 -1.222161e+01
+     vertex -6.102615e+01 -2.497041e+01 -1.912132e+01
+   endloop
+ endfacet
+ facet normal -1.790410e-01 -4.740747e-01 -8.620890e-01
+   outer loop
+     vertex -6.102615e+01 -1.916836e+01 -2.493432e+01
+     vertex -5.723626e+01 -1.223753e+01 -2.953277e+01
+     vertex -5.398779e+01 -1.709365e+01 -2.753698e+01
+   endloop
+ endfacet
+ facet normal -8.355806e-02 -6.567320e-01 -7.494806e-01
+   outer loop
+     vertex -6.102615e+01 -1.916836e+01 -2.493432e+01
+     vertex -5.398779e+01 -1.709365e+01 -2.753698e+01
+     vertex -5.561202e+01 -2.454137e+01 -2.082983e+01
+   endloop
+ endfacet
+ facet normal -1.148175e-01 -5.048471e-01 -8.555386e-01
+   outer loop
+     vertex -6.102615e+01 -1.916836e+01 -2.493432e+01
+     vertex -7.185439e+01 -1.585813e+01 -2.543446e+01
+     vertex -5.723626e+01 -1.223753e+01 -2.953277e+01
+   endloop
+ endfacet
+ facet normal -1.472072e-01 -6.003078e-01 -7.861047e-01
+   outer loop
+     vertex -6.102615e+01 -1.916836e+01 -2.493432e+01
+     vertex -6.454533e+01 -2.007759e+01 -2.358098e+01
+     vertex -7.185439e+01 -1.585813e+01 -2.543446e+01
+   endloop
+ endfacet
+ facet normal -8.845791e-02 -7.049985e-01 -7.036706e-01
+   outer loop
+     vertex -6.102615e+01 -1.916836e+01 -2.493432e+01
+     vertex -6.102615e+01 -2.497041e+01 -1.912132e+01
+     vertex -6.454533e+01 -2.007759e+01 -2.358098e+01
+   endloop
+ endfacet
+ facet normal -1.645663e-01 -6.981232e-01 -6.968084e-01
+   outer loop
+     vertex -6.102615e+01 -1.916836e+01 -2.493432e+01
+     vertex -5.561202e+01 -2.454137e+01 -2.082983e+01
+     vertex -6.102615e+01 -2.497041e+01 -1.912132e+01
+   endloop
+ endfacet
+ facet normal -1.244453e-01 -6.487311e-01 -7.507738e-01
+   outer loop
+     vertex -5.290496e+01 -2.492055e+01 -2.095337e+01
+     vertex -5.398779e+01 -1.709365e+01 -2.753698e+01
+     vertex -4.749084e+01 -2.568388e+01 -2.119121e+01
+   endloop
+ endfacet
+ facet normal -1.385690e-01 -8.016411e-01 -5.815241e-01
+   outer loop
+     vertex -5.290496e+01 -2.492055e+01 -2.095337e+01
+     vertex -4.749084e+01 -2.568388e+01 -2.119121e+01
+     vertex -4.749084e+01 -2.811712e+01 -1.783695e+01
+   endloop
+ endfacet
+ facet normal -1.841964e-01 -8.281228e-01 -5.294188e-01
+   outer loop
+     vertex -5.290496e+01 -2.492055e+01 -2.095337e+01
+     vertex -4.749084e+01 -2.811712e+01 -1.783695e+01
+     vertex -5.723626e+01 -2.953937e+01 -1.222161e+01
+   endloop
+ endfacet
+ facet normal -1.251241e-01 -6.487306e-01 -7.506615e-01
+   outer loop
+     vertex -5.290496e+01 -2.492055e+01 -2.095337e+01
+     vertex -5.561202e+01 -2.454137e+01 -2.082983e+01
+     vertex -5.398779e+01 -1.709365e+01 -2.753698e+01
+   endloop
+ endfacet
+ facet normal -1.418363e-01 -8.442054e-01 -5.169137e-01
+   outer loop
+     vertex -5.290496e+01 -2.492055e+01 -2.095337e+01
+     vertex -5.723626e+01 -2.953937e+01 -1.222161e+01
+     vertex -5.561202e+01 -2.454137e+01 -2.082983e+01
+   endloop
+ endfacet
+ facet normal -9.118642e-02  1.145993e-01 -9.892179e-01
+   outer loop
+     vertex -2.500000e+01  8.252439e+00 -3.527761e+01
+     vertex -2.800000e+01  2.050521e-05 -3.595710e+01
+     vertex -2.800000e+01  8.220769e+00 -3.500474e+01
+   endloop
+ endfacet
+ facet normal -8.999909e-02  1.141806e-01 -9.893750e-01
+   outer loop
+     vertex -2.500000e+01  8.252439e+00 -3.527761e+01
+     vertex -2.500000e+01  9.217895e-15 -3.623000e+01
+     vertex -2.800000e+01  2.050521e-05 -3.595710e+01
+   endloop
+ endfacet
+ facet normal -9.236731e-02  3.376883e-01 -9.367150e-01
+   outer loop
+     vertex -2.500000e+01  1.607102e+01 -3.247053e+01
+     vertex -2.800000e+01  8.220769e+00 -3.500474e+01
+     vertex -2.800000e+01  1.600606e+01 -3.219812e+01
+   endloop
+ endfacet
+ facet normal -8.882187e-02  3.365735e-01 -9.374588e-01
+   outer loop
+     vertex -2.500000e+01  1.607102e+01 -3.247053e+01
+     vertex -2.500000e+01  8.252439e+00 -3.527761e+01
+     vertex -2.800000e+01  8.220769e+00 -3.500474e+01
+   endloop
+ endfacet
+ facet normal -9.353888e-02  5.428427e-01 -8.346091e-01
+   outer loop
+     vertex -2.500000e+01  2.304469e+01 -2.795632e+01
+     vertex -2.800000e+01  1.600606e+01 -3.219812e+01
+     vertex -2.800000e+01  2.294349e+01 -2.768591e+01
+   endloop
+ endfacet
+ facet normal -8.765319e-02  5.413158e-01 -8.362381e-01
+   outer loop
+     vertex -2.500000e+01  2.304469e+01 -2.795632e+01
+     vertex -2.500000e+01  1.607102e+01 -3.247053e+01
+     vertex -2.800000e+01  1.600606e+01 -3.219812e+01
+   endloop
+ endfacet
+ facet normal -9.470106e-02  7.192002e-01 -6.883188e-01
+   outer loop
+     vertex -2.500000e+01  2.880677e+01 -2.197232e+01
+     vertex -2.800000e+01  2.294349e+01 -2.768591e+01
+     vertex -2.800000e+01  2.866555e+01 -2.170713e+01
+   endloop
+ endfacet
+ facet normal -8.649307e-02  7.176375e-01 -6.910249e-01
+   outer loop
+     vertex -2.500000e+01  2.880677e+01 -2.197232e+01
+     vertex -2.500000e+01  2.304469e+01 -2.795632e+01
+     vertex -2.800000e+01  2.294349e+01 -2.768591e+01
+   endloop
+ endfacet
+ facet normal -9.585386e-02  8.574248e-01 -5.056033e-01
+   outer loop
+     vertex -2.500000e+01  3.305436e+01 -1.483314e+01
+     vertex -2.800000e+01  2.866555e+01 -2.170713e+01
+     vertex -2.800000e+01  3.286914e+01 -1.457849e+01
+   endloop
+ endfacet
+ facet normal -8.534153e-02  8.562596e-01 -5.094472e-01
+   outer loop
+     vertex -2.500000e+01  3.305436e+01 -1.483314e+01
+     vertex -2.500000e+01  2.880677e+01 -2.197232e+01
+     vertex -2.800000e+01  2.866555e+01 -2.170713e+01
+   endloop
+ endfacet
+ facet normal -9.699732e-02  9.502038e-01 -2.961491e-01
+   outer loop
+     vertex -2.500000e+01  3.556413e+01 -6.914115e+00
+     vertex -2.800000e+01  3.286914e+01 -1.457849e+01
+     vertex -2.800000e+01  3.533161e+01 -6.677595e+00
+   endloop
+ endfacet
+ facet normal -8.419858e-02  9.498850e-01 -3.010467e-01
+   outer loop
+     vertex -2.500000e+01  3.556413e+01 -6.914115e+00
+     vertex -2.500000e+01  3.305436e+01 -1.483314e+01
+     vertex -2.800000e+01  3.286914e+01 -1.457849e+01
+   endloop
+ endfacet
+ facet normal -9.813146e-02  9.926335e-01 -7.105602e-02
+   outer loop
+     vertex -2.500000e+01  3.620415e+01  1.368415e+00
+     vertex -2.800000e+01  3.533161e+01 -6.677595e+00
+     vertex -2.800000e+01  3.592250e+01  1.577020e+00
+   endloop
+ endfacet
+ facet normal -8.306421e-02  9.935822e-01 -7.677681e-02
+   outer loop
+     vertex -2.500000e+01  3.620415e+01  1.368415e+00
+     vertex -2.500000e+01  3.556413e+01 -6.914115e+00
+     vertex -2.800000e+01  3.533161e+01 -6.677595e+00
+   endloop
+ endfacet
+ facet normal -9.925629e-02  9.824779e-01  1.577508e-01
+   outer loop
+     vertex -2.500000e+01  3.494075e+01  9.579001e+00
+     vertex -2.800000e+01  3.592250e+01  1.577020e+00
+     vertex -2.800000e+01  3.461052e+01  9.748097e+00
+   endloop
+ endfacet
+ facet normal -8.193846e-02  9.850440e-01  1.515730e-01
+   outer loop
+     vertex -2.500000e+01  3.494075e+01  9.579001e+00
+     vertex -2.500000e+01  3.620415e+01  1.368415e+00
+     vertex -2.800000e+01  3.592250e+01  1.577020e+00
+   endloop
+ endfacet
+ facet normal -1.003718e-01  9.202864e-01  3.781513e-01
+   outer loop
+     vertex -2.500000e+01  3.184035e+01  1.728598e+01
+     vertex -2.800000e+01  3.461052e+01  9.748097e+00
+     vertex -2.800000e+01  3.146515e+01  1.740280e+01
+   endloop
+ endfacet
+ facet normal -8.082132e-02  9.247092e-01  3.719957e-01
+   outer loop
+     vertex -2.500000e+01  3.184035e+01  1.728598e+01
+     vertex -2.500000e+01  3.494075e+01  9.579001e+00
+     vertex -2.800000e+01  3.461052e+01  9.748097e+00
+   endloop
+ endfacet
+ facet normal -1.014779e-01  8.093648e-01  5.784728e-01
+   outer loop
+     vertex -2.500000e+01  2.706597e+01  2.408415e+01
+     vertex -2.800000e+01  3.146515e+01  1.740280e+01
+     vertex -2.800000e+01  2.665302e+01  2.413565e+01
+   endloop
+ endfacet
+ facet normal -7.971283e-02  8.157410e-01  5.728983e-01
+   outer loop
+     vertex -2.500000e+01  2.706597e+01  2.408415e+01
+     vertex -2.500000e+01  3.184035e+01  1.728598e+01
+     vertex -2.800000e+01  3.146515e+01  1.740280e+01
+   endloop
+ endfacet
+ facet normal -7.861300e-02  6.638611e-01  7.437126e-01
+   outer loop
+     vertex -2.500000e+01  2.086860e+01  2.961612e+01
+     vertex -2.500000e+01  2.706597e+01  2.408415e+01
+     vertex -2.800000e+01  2.665302e+01  2.413565e+01
+   endloop
+ endfacet
+ facet normal -1.025746e-01  6.555995e-01  7.481094e-01
+   outer loop
+     vertex -2.500000e+01  2.086860e+01  2.961612e+01
+     vertex -2.800000e+01  2.665302e+01  2.413565e+01
+     vertex -2.800000e+01  2.042903e+01  2.958999e+01
+   endloop
+ endfacet
+ facet normal -7.752183e-02  4.770487e-01  8.754513e-01
+   outer loop
+     vertex -2.500000e+01  1.357408e+01  3.359103e+01
+     vertex -2.500000e+01  2.086860e+01  2.961612e+01
+     vertex -2.800000e+01  2.042903e+01  2.958999e+01
+   endloop
+ endfacet
+ facet normal -1.036621e-01  4.671448e-01  8.780831e-01
+   outer loop
+     vertex -2.500000e+01  1.357408e+01  3.359103e+01
+     vertex -2.800000e+01  2.042903e+01  2.958999e+01
+     vertex -2.800000e+01  1.312289e+01  3.347690e+01
+   endloop
+ endfacet
+ facet normal -7.643932e-02  2.651210e-01  9.611805e-01
+   outer loop
+     vertex -2.500000e+01  5.565913e+00  3.579991e+01
+     vertex -2.500000e+01  1.357408e+01  3.359103e+01
+     vertex -2.800000e+01  1.312289e+01  3.347690e+01
+   endloop
+ endfacet
+ facet normal -1.047402e-01  2.539900e-01  9.615189e-01
+   outer loop
+     vertex -2.500000e+01  5.565913e+00  3.579991e+01
+     vertex -2.800000e+01  1.312289e+01  3.347690e+01
+     vertex -2.800000e+01  5.121600e+00  3.559048e+01
+   endloop
+ endfacet
+ facet normal -1.058091e-01  2.743077e-02  9.940080e-01
+   outer loop
+     vertex -2.500000e+01 -2.734876e+00  3.612663e+01
+     vertex -2.800000e+01  5.121600e+00  3.559048e+01
+     vertex -2.800000e+01 -3.150983e+00  3.581877e+01
+   endloop
+ endfacet
+ facet normal -7.536549e-02  3.921784e-02  9.963845e-01
+   outer loop
+     vertex -2.500000e+01 -2.734876e+00  3.612663e+01
+     vertex -2.500000e+01  5.565913e+00  3.579991e+01
+     vertex -2.800000e+01  5.121600e+00  3.559048e+01
+   endloop
+ endfacet
+ facet normal -1.068686e-01 -2.005298e-01  9.738413e-01
+   outer loop
+     vertex -2.500000e+01 -1.089188e+01  3.455401e+01
+     vertex -2.800000e+01 -3.150983e+00  3.581877e+01
+     vertex -2.800000e+01 -1.125665e+01  3.414968e+01
+   endloop
+ endfacet
+ facet normal -7.430036e-02 -1.887841e-01  9.792038e-01
+   outer loop
+     vertex -2.500000e+01 -1.089188e+01  3.455401e+01
+     vertex -2.500000e+01 -2.734876e+00  3.612663e+01
+     vertex -2.800000e+01 -3.150983e+00  3.581877e+01
+   endloop
+ endfacet
+ facet normal -1.079188e-01 -4.178170e-01  9.020989e-01
+   outer loop
+     vertex -2.500000e+01 -1.847626e+01  3.116474e+01
+     vertex -2.800000e+01 -1.125665e+01  3.414968e+01
+     vertex -2.800000e+01 -1.876605e+01  3.067162e+01
+   endloop
+ endfacet
+ facet normal -7.324394e-02 -4.068957e-01  9.105335e-01
+   outer loop
+     vertex -2.500000e+01 -1.847626e+01  3.116474e+01
+     vertex -2.500000e+01 -1.089188e+01  3.455401e+01
+     vertex -2.800000e+01 -1.125665e+01  3.414968e+01
+   endloop
+ endfacet
+ facet normal -1.089597e-01 -6.129246e-01  7.825926e-01
+   outer loop
+     vertex -2.500000e+01 -2.508925e+01  2.613699e+01
+     vertex -2.800000e+01 -1.876605e+01  3.067162e+01
+     vertex -2.800000e+01 -2.528137e+01  2.556884e+01
+   endloop
+ endfacet
+ facet normal -7.219623e-02 -6.036464e-01  7.939766e-01
+   outer loop
+     vertex -2.500000e+01 -2.508925e+01  2.613699e+01
+     vertex -2.500000e+01 -1.847626e+01  3.116474e+01
+     vertex -2.800000e+01 -1.876605e+01  3.067162e+01
+   endloop
+ endfacet
+ facet normal -1.099913e-01 -7.755238e-01  6.216629e-01
+   outer loop
+     vertex -2.500000e+01 -3.038320e+01  1.973510e+01
+     vertex -2.800000e+01 -2.528137e+01  2.556884e+01
+     vertex -2.800000e+01 -3.045750e+01  1.911163e+01
+   endloop
+ endfacet
+ facet normal -7.115723e-02 -7.686872e-01  6.356545e-01
+   outer loop
+     vertex -2.500000e+01 -3.038320e+01  1.973510e+01
+     vertex -2.500000e+01 -2.508925e+01  2.613699e+01
+     vertex -2.800000e+01 -2.528137e+01  2.556884e+01
+   endloop
+ endfacet
+ facet normal -1.110137e-01 -8.970097e-01  4.278429e-01
+   outer loop
+     vertex -2.500000e+01 -3.407976e+01  1.229566e+01
+     vertex -2.800000e+01 -3.045750e+01  1.911163e+01
+     vertex -2.800000e+01 -3.402023e+01  1.164204e+01
+   endloop
+ endfacet
+ facet normal -7.012696e-02 -8.933350e-01  4.438860e-01
+   outer loop
+     vertex -2.500000e+01 -3.407976e+01  1.229566e+01
+     vertex -2.500000e+01 -3.038320e+01  1.973510e+01
+     vertex -2.800000e+01 -3.045750e+01  1.911163e+01
+   endloop
+ endfacet
+ facet normal -1.120267e-01 -9.709570e-01  2.114060e-01
+   outer loop
+     vertex -2.500000e+01 -3.598459e+01  4.209773e+00
+     vertex -2.800000e+01 -3.402023e+01  1.164204e+01
+     vertex -2.800000e+01 -3.578086e+01  3.555754e+00
+   endloop
+ endfacet
+ facet normal -6.910546e-02 -9.710293e-01  2.287501e-01
+   outer loop
+     vertex -2.500000e+01 -3.598459e+01  4.209773e+00
+     vertex -2.500000e+01 -3.407976e+01  1.229566e+01
+     vertex -2.800000e+01 -3.402023e+01  1.164204e+01
+   endloop
+ endfacet
+ facet normal -1.130304e-01 -9.934598e-01 -1.617822e-02
+   outer loop
+     vertex -2.500000e+01 -3.599755e+01 -4.097437e+00
+     vertex -2.800000e+01 -3.578086e+01  3.555754e+00
+     vertex -2.800000e+01 -3.564611e+01 -4.718885e+00
+   endloop
+ endfacet
+ facet normal -6.809276e-02 -9.976778e-01  1.556448e-03
+   outer loop
+     vertex -2.500000e+01 -3.599755e+01 -4.097437e+00
+     vertex -2.500000e+01 -3.598459e+01  4.209773e+00
+     vertex -2.800000e+01 -3.578086e+01  3.555754e+00
+   endloop
+ endfacet
+ facet normal -1.140248e-01 -9.633384e-01 -2.428530e-01
+   outer loop
+     vertex -2.500000e+01 -3.411796e+01 -1.218923e+01
+     vertex -2.800000e+01 -3.564611e+01 -4.718885e+00
+     vertex -2.800000e+01 -3.362313e+01 -1.274356e+01
+   endloop
+ endfacet
+ facet normal -6.708883e-02 -9.718725e-01 -2.257498e-01
+   outer loop
+     vertex -2.500000e+01 -3.411796e+01 -1.218923e+01
+     vertex -2.500000e+01 -3.599755e+01 -4.097437e+00
+     vertex -2.800000e+01 -3.564611e+01 -4.718885e+00
+   endloop
+ endfacet
+ facet normal -1.150101e-01 -8.822002e-01 -4.566130e-01
+   outer loop
+     vertex -2.500000e+01 -3.044465e+01 -1.964018e+01
+     vertex -2.800000e+01 -3.362313e+01 -1.274356e+01
+     vertex -2.800000e+01 -2.981907e+01 -2.009318e+01
+   endloop
+ endfacet
+ facet normal -6.609361e-02 -8.949633e-01 -4.412168e-01
+   outer loop
+     vertex -2.500000e+01 -3.044465e+01 -1.964018e+01
+     vertex -2.500000e+01 -3.411796e+01 -1.218923e+01
+     vertex -2.800000e+01 -3.362313e+01 -1.274356e+01
+   endloop
+ endfacet
+ facet normal -1.159861e-01 -7.543541e-01 -6.461401e-01
+   outer loop
+     vertex -2.500000e+01 -2.517072e+01 -2.605855e+01
+     vertex -2.800000e+01 -2.981907e+01 -2.009318e+01
+     vertex -2.800000e+01 -2.443546e+01 -2.637844e+01
+   endloop
+ endfacet
+ facet normal -6.510711e-02 -7.709872e-01 -6.335138e-01
+   outer loop
+     vertex -2.500000e+01 -2.517072e+01 -2.605855e+01
+     vertex -2.500000e+01 -3.044465e+01 -1.964018e+01
+     vertex -2.800000e+01 -2.981907e+01 -2.009318e+01
+   endloop
+ endfacet
+ facet normal -1.169528e-01 -5.865818e-01 -8.014011e-01
+   outer loop
+     vertex -2.500000e+01 -1.857344e+01 -3.110691e+01
+     vertex -2.800000e+01 -2.443546e+01 -2.637844e+01
+     vertex -2.800000e+01 -1.775744e+01 -3.126638e+01
+   endloop
+ endfacet
+ facet normal -6.412942e-02 -6.064565e-01 -7.925263e-01
+   outer loop
+     vertex -2.500000e+01 -1.857344e+01 -3.110691e+01
+     vertex -2.500000e+01 -2.517072e+01 -2.605855e+01
+     vertex -2.800000e+01 -2.443546e+01 -2.637844e+01
+   endloop
+ endfacet
+ facet normal -1.179101e-01 -3.877796e-01 -9.141795e-01
+   outer loop
+     vertex -2.500000e+01 -1.099968e+01 -3.451985e+01
+     vertex -2.800000e+01 -1.775744e+01 -3.126638e+01
+     vertex -2.800000e+01 -1.013878e+01 -3.449809e+01
+   endloop
+ endfacet
+ facet normal -6.316067e-02 -4.100185e-01 -9.098877e-01
+   outer loop
+     vertex -2.500000e+01 -1.099968e+01 -3.451985e+01
+     vertex -2.500000e+01 -1.857344e+01 -3.110691e+01
+     vertex -2.800000e+01 -1.775744e+01 -3.126638e+01
+   endloop
+ endfacet
+ facet normal -9.922783e-02 -2.116958e-01 -9.722853e-01
+   outer loop
+     vertex -2.500000e+01 -5.565910e+00 -3.579991e+01
+     vertex -2.800000e+01 -1.013878e+01 -3.449809e+01
+     vertex -2.800000e+01 -5.121597e+00 -3.559048e+01
+   endloop
+ endfacet
+ facet normal -7.266795e-02 -2.286925e-01 -9.707827e-01
+   outer loop
+     vertex -2.500000e+01 -5.565910e+00 -3.579991e+01
+     vertex -2.500000e+01 -1.099968e+01 -3.451985e+01
+     vertex -2.800000e+01 -1.013878e+01 -3.449809e+01
+   endloop
+ endfacet
+ facet normal -9.036349e-02 -7.110830e-02 -9.933670e-01
+   outer loop
+     vertex -2.500000e+01  9.217895e-15 -3.623000e+01
+     vertex -2.800000e+01 -5.121597e+00 -3.559048e+01
+     vertex -2.800000e+01  2.050521e-05 -3.595710e+01
+   endloop
+ endfacet
+ facet normal -8.074788e-02 -7.679127e-02 -9.937720e-01
+   outer loop
+     vertex -2.500000e+01  9.217895e-15 -3.623000e+01
+     vertex -2.500000e+01 -5.565910e+00 -3.579991e+01
+     vertex -2.800000e+01 -5.121597e+00 -3.559048e+01
+   endloop
+ endfacet
+ facet normal -7.502332e-02 -7.682572e-02 -9.942179e-01
+   outer loop
+     vertex -2.500000e+01 -5.565910e+00 -3.579991e+01
+     vertex -2.500000e+01  9.217895e-15 -3.623000e+01
+     vertex -2.790418e+00 -1.894995e-15 -3.790593e+01
+   endloop
+ endfacet
+ facet normal  9.749020e-02  7.667492e-02 -9.922785e-01
+   outer loop
+     vertex  1.115216e+01 -4.749220e-15 -3.759053e+01
+     vertex  2.500000e+01  5.565912e+00 -3.579991e+01
+     vertex  2.500000e+01 -1.626709e-09 -3.623000e+01
+   endloop
+ endfacet
+ facet normal -7.475252e-02 -4.096893e-01 -9.091572e-01
+   outer loop
+     vertex -2.790418e+00 -1.150851e+01 -3.611667e+01
+     vertex -2.500000e+01 -1.857344e+01 -3.110691e+01
+     vertex -2.500000e+01 -1.099968e+01 -3.451985e+01
+   endloop
+ endfacet
+ facet normal -7.502342e-02 -2.286525e-01 -9.706130e-01
+   outer loop
+     vertex -2.790418e+00 -1.150851e+01 -3.611667e+01
+     vertex -2.500000e+01 -1.099968e+01 -3.451985e+01
+     vertex -2.500000e+01 -5.565910e+00 -3.579991e+01
+   endloop
+ endfacet
+ facet normal -5.511490e-02 -1.533938e-01 -9.866269e-01
+   outer loop
+     vertex -2.790418e+00 -1.150851e+01 -3.611667e+01
+     vertex -2.500000e+01 -5.565910e+00 -3.579991e+01
+     vertex -2.790418e+00 -1.894995e-15 -3.790593e+01
+   endloop
+ endfacet
+ facet normal -8.478964e-02 -6.055190e-01 -7.913011e-01
+   outer loop
+     vertex -2.790418e+00 -2.411068e+01 -2.924952e+01
+     vertex -2.500000e+01 -2.517072e+01 -2.605855e+01
+     vertex -2.500000e+01 -1.857344e+01 -3.110691e+01
+   endloop
+ endfacet
+ facet normal -4.581214e-02 -4.779864e-01 -8.771718e-01
+   outer loop
+     vertex -2.790418e+00 -2.411068e+01 -2.924952e+01
+     vertex -2.500000e+01 -1.857344e+01 -3.110691e+01
+     vertex -2.790418e+00 -1.150851e+01 -3.611667e+01
+   endloop
+ endfacet
+ facet normal -6.513718e-02 -7.188070e-01 -6.921514e-01
+   outer loop
+     vertex -2.790418e+00 -3.013931e+01 -2.298872e+01
+     vertex -2.500000e+01 -2.517072e+01 -2.605855e+01
+     vertex -2.790418e+00 -2.411068e+01 -2.924952e+01
+   endloop
+ endfacet
+ facet normal -8.478969e-02 -7.698442e-01 -6.325746e-01
+   outer loop
+     vertex -2.790418e+00 -3.013931e+01 -2.298872e+01
+     vertex -2.500000e+01 -3.044465e+01 -1.964018e+01
+     vertex -2.500000e+01 -2.517072e+01 -2.605855e+01
+   endloop
+ endfacet
+ facet normal -8.478989e-02 -8.936946e-01 -4.405913e-01
+   outer loop
+     vertex -2.790418e+00 -3.458339e+01 -1.551929e+01
+     vertex -2.500000e+01 -3.411796e+01 -1.218923e+01
+     vertex -2.500000e+01 -3.044465e+01 -1.964018e+01
+   endloop
+ endfacet
+ facet normal -6.513735e-02 -8.575694e-01 -5.102273e-01
+   outer loop
+     vertex -2.790418e+00 -3.458339e+01 -1.551929e+01
+     vertex -2.500000e+01 -3.044465e+01 -1.964018e+01
+     vertex -2.790418e+00 -3.013931e+01 -2.298872e+01
+   endloop
+ endfacet
+ facet normal -6.513757e-02 -9.512455e-01 -3.014782e-01
+   outer loop
+     vertex -2.790418e+00 -3.720926e+01 -7.233949e+00
+     vertex -2.500000e+01 -3.411796e+01 -1.218923e+01
+     vertex -2.790418e+00 -3.458339e+01 -1.551929e+01
+   endloop
+ endfacet
+ facet normal -8.478996e-02 -9.705593e-01 -2.254448e-01
+   outer loop
+     vertex -2.790418e+00 -3.720926e+01 -7.233949e+00
+     vertex -2.500000e+01 -3.599755e+01 -4.097437e+00
+     vertex -2.500000e+01 -3.411796e+01 -1.218923e+01
+   endloop
+ endfacet
+ facet normal -6.513756e-02 -9.949104e-01 -7.687903e-02
+   outer loop
+     vertex -2.790418e+00 -3.787888e+01  1.431714e+00
+     vertex -2.500000e+01 -3.599755e+01 -4.097437e+00
+     vertex -2.790418e+00 -3.720926e+01 -7.233949e+00
+   endloop
+ endfacet
+ facet normal  5.980108e-02 -9.952434e-01 -7.690519e-02
+   outer loop
+     vertex -2.790418e+00 -3.787888e+01  1.431714e+00
+     vertex  2.500000e+01 -3.556413e+01 -6.914116e+00
+     vertex  2.500000e+01 -3.620415e+01  1.368414e+00
+   endloop
+ endfacet
+ facet normal  5.980121e-02 -9.952434e-01 -7.690476e-02
+   outer loop
+     vertex -2.790418e+00 -3.787888e+01  1.431714e+00
+     vertex -2.790418e+00 -3.720926e+01 -7.233949e+00
+     vertex  2.500000e+01 -3.556413e+01 -6.914116e+00
+   endloop
+ endfacet
+ facet normal -8.478983e-02 -9.963976e-01  1.554451e-03
+   outer loop
+     vertex -2.790418e+00 -3.787888e+01  1.431714e+00
+     vertex -2.500000e+01 -3.598459e+01  4.209773e+00
+     vertex -2.500000e+01 -3.599755e+01 -4.097437e+00
+   endloop
+ endfacet
+ facet normal  5.980092e-02 -9.865986e-01  1.518122e-01
+   outer loop
+     vertex -2.790418e+00 -3.655703e+01  1.002211e+01
+     vertex  2.500000e+01 -3.620415e+01  1.368414e+00
+     vertex  2.500000e+01 -3.494075e+01  9.579001e+00
+   endloop
+ endfacet
+ facet normal -8.478965e-02 -9.698510e-01  2.284725e-01
+   outer loop
+     vertex -2.790418e+00 -3.655703e+01  1.002211e+01
+     vertex -2.500000e+01 -3.407976e+01  1.229566e+01
+     vertex -2.500000e+01 -3.598459e+01  4.209773e+00
+   endloop
+ endfacet
+ facet normal -6.513736e-02 -9.862684e-01  1.517620e-01
+   outer loop
+     vertex -2.790418e+00 -3.655703e+01  1.002211e+01
+     vertex -2.500000e+01 -3.598459e+01  4.209773e+00
+     vertex -2.790418e+00 -3.787888e+01  1.431714e+00
+   endloop
+ endfacet
+ facet normal  5.980109e-02 -9.865986e-01  1.518128e-01
+   outer loop
+     vertex -2.790418e+00 -3.655703e+01  1.002211e+01
+     vertex -2.790418e+00 -3.787888e+01  1.431714e+00
+     vertex  2.500000e+01 -3.620415e+01  1.368414e+00
+   endloop
+ endfacet
+ facet normal  5.980089e-02 -9.260839e-01  3.725487e-01
+   outer loop
+     vertex -2.790418e+00 -3.331322e+01  1.808559e+01
+     vertex  2.500000e+01 -3.494075e+01  9.579001e+00
+     vertex  2.500000e+01 -3.184036e+01  1.728598e+01
+   endloop
+ endfacet
+ facet normal -8.478962e-02 -8.923148e-01  4.433791e-01
+   outer loop
+     vertex -2.790418e+00 -3.331322e+01  1.808559e+01
+     vertex -2.500000e+01 -3.038320e+01  1.973510e+01
+     vertex -2.500000e+01 -3.407976e+01  1.229566e+01
+   endloop
+ endfacet
+ facet normal  5.980093e-02 -9.260838e-01  3.725489e-01
+   outer loop
+     vertex -2.790418e+00 -3.331322e+01  1.808559e+01
+     vertex -2.790418e+00 -3.655703e+01  1.002211e+01
+     vertex  2.500000e+01 -3.494075e+01  9.579001e+00
+   endloop
+ endfacet
+ facet normal -6.513721e-02 -9.257739e-01  3.724242e-01
+   outer loop
+     vertex -2.790418e+00 -3.331322e+01  1.808559e+01
+     vertex -2.500000e+01 -3.407976e+01  1.229566e+01
+     vertex -2.790418e+00 -3.655703e+01  1.002211e+01
+   endloop
+ endfacet
+ facet normal  5.980098e-02 -8.168805e-01  5.736986e-01
+   outer loop
+     vertex -2.790418e+00 -2.831798e+01  2.519824e+01
+     vertex  2.500000e+01 -3.184036e+01  1.728598e+01
+     vertex  2.500000e+01 -2.706597e+01  2.408415e+01
+   endloop
+ endfacet
+ facet normal -8.478972e-02 -7.678655e-01  6.349750e-01
+   outer loop
+     vertex -2.790418e+00 -2.831798e+01  2.519824e+01
+     vertex -2.500000e+01 -2.508925e+01  2.613699e+01
+     vertex -2.500000e+01 -3.038320e+01  1.973510e+01
+   endloop
+ endfacet
+ facet normal  5.980090e-02 -8.168807e-01  5.736984e-01
+   outer loop
+     vertex -2.790418e+00 -2.831798e+01  2.519824e+01
+     vertex -2.790418e+00 -3.331322e+01  1.808559e+01
+     vertex  2.500000e+01 -3.184036e+01  1.728598e+01
+   endloop
+ endfacet
+ facet normal -6.513723e-02 -8.166073e-01  5.735064e-01
+   outer loop
+     vertex -2.790418e+00 -2.831798e+01  2.519824e+01
+     vertex -2.500000e+01 -3.038320e+01  1.973510e+01
+     vertex -2.790418e+00 -3.331322e+01  1.808559e+01
+   endloop
+ endfacet
+ facet normal  5.980099e-02 -6.647305e-01  7.446860e-01
+   outer loop
+     vertex -2.790418e+00 -2.183394e+01  3.098610e+01
+     vertex -2.790418e+00 -2.831798e+01  2.519824e+01
+     vertex  2.500000e+01 -2.706597e+01  2.408415e+01
+   endloop
+ endfacet
+ facet normal  5.980109e-02 -6.647302e-01  7.446862e-01
+   outer loop
+     vertex -2.790418e+00 -2.183394e+01  3.098610e+01
+     vertex  2.500000e+01 -2.706597e+01  2.408415e+01
+     vertex  2.500000e+01 -2.086860e+01  2.961612e+01
+   endloop
+ endfacet
+ facet normal  5.980107e-02 -4.776323e-01  8.765222e-01
+   outer loop
+     vertex -2.790418e+00 -2.183394e+01  3.098610e+01
+     vertex  2.500000e+01 -2.086860e+01  2.961612e+01
+     vertex  2.500000e+01 -1.357408e+01  3.359103e+01
+   endloop
+ endfacet
+ facet normal -8.478983e-02 -6.030462e-01  7.931872e-01
+   outer loop
+     vertex -2.790418e+00 -2.183394e+01  3.098610e+01
+     vertex -2.500000e+01 -1.847626e+01  3.116474e+01
+     vertex -2.500000e+01 -2.508925e+01  2.613699e+01
+   endloop
+ endfacet
+ facet normal -6.513735e-02 -6.645081e-01  7.444368e-01
+   outer loop
+     vertex -2.790418e+00 -2.183394e+01  3.098610e+01
+     vertex -2.500000e+01 -2.508925e+01  2.613699e+01
+     vertex -2.790418e+00 -2.831798e+01  2.519824e+01
+   endloop
+ endfacet
+ facet normal -6.513744e-02 -4.774726e-01  8.762289e-01
+   outer loop
+     vertex -2.790418e+00 -1.420200e+01  3.514488e+01
+     vertex -2.500000e+01 -1.847626e+01  3.116474e+01
+     vertex -2.790418e+00 -2.183394e+01  3.098610e+01
+   endloop
+ endfacet
+ facet normal -8.478985e-02 -4.065223e-01  9.096979e-01
+   outer loop
+     vertex -2.790418e+00 -1.420200e+01  3.514488e+01
+     vertex -2.500000e+01 -1.089188e+01  3.455401e+01
+     vertex -2.500000e+01 -1.847626e+01  3.116474e+01
+   endloop
+ endfacet
+ facet normal  5.980111e-02 -4.776324e-01  8.765222e-01
+   outer loop
+     vertex -2.790418e+00 -1.420200e+01  3.514488e+01
+     vertex -2.790418e+00 -2.183394e+01  3.098610e+01
+     vertex  2.500000e+01 -1.357408e+01  3.359103e+01
+   endloop
+ endfacet
+ facet normal  5.980108e-02 -2.654231e-01  9.622756e-01
+   outer loop
+     vertex -2.790418e+00 -5.823386e+00  3.745594e+01
+     vertex -2.790418e+00 -1.420200e+01  3.514488e+01
+     vertex  2.500000e+01 -1.357408e+01  3.359103e+01
+   endloop
+ endfacet
+ facet normal  5.980108e-02 -2.654231e-01  9.622756e-01
+   outer loop
+     vertex -2.790418e+00 -5.823386e+00  3.745594e+01
+     vertex  2.500000e+01 -1.357408e+01  3.359103e+01
+     vertex  2.500000e+01 -5.565915e+00  3.579991e+01
+   endloop
+ endfacet
+ facet normal -6.513743e-02 -2.653343e-01  9.619536e-01
+   outer loop
+     vertex -2.790418e+00 -5.823386e+00  3.745594e+01
+     vertex -2.500000e+01 -1.089188e+01  3.455401e+01
+     vertex -2.790418e+00 -1.420200e+01  3.514488e+01
+   endloop
+ endfacet
+ facet normal -8.478981e-02 -1.886256e-01  9.783819e-01
+   outer loop
+     vertex -2.790418e+00 -5.823386e+00  3.745594e+01
+     vertex -2.500000e+01 -2.734876e+00  3.612663e+01
+     vertex -2.500000e+01 -1.089188e+01  3.455401e+01
+   endloop
+ endfacet
+ facet normal  5.980105e-02 -3.925935e-02  9.974380e-01
+   outer loop
+     vertex -2.790418e+00  2.861386e+00  3.779777e+01
+     vertex  2.500000e+01 -5.565915e+00  3.579991e+01
+     vertex  2.500000e+01  2.734875e+00  3.612663e+01
+   endloop
+ endfacet
+ facet normal  5.980106e-02  1.889685e-01  9.801606e-01
+   outer loop
+     vertex -2.790418e+00  2.861386e+00  3.779777e+01
+     vertex  2.500000e+01  2.734875e+00  3.612663e+01
+     vertex  2.500000e+01  1.089188e+01  3.455401e+01
+   endloop
+ endfacet
+ facet normal  5.980105e-02 -3.925934e-02  9.974380e-01
+   outer loop
+     vertex -2.790418e+00  2.861386e+00  3.779777e+01
+     vertex -2.790418e+00 -5.823386e+00  3.745594e+01
+     vertex  2.500000e+01 -5.565915e+00  3.579991e+01
+   endloop
+ endfacet
+ facet normal -6.513740e-02 -3.924621e-02  9.971042e-01
+   outer loop
+     vertex -2.790418e+00  2.861386e+00  3.779777e+01
+     vertex -2.500000e+01 -2.734876e+00  3.612663e+01
+     vertex -2.790418e+00 -5.823386e+00  3.745594e+01
+   endloop
+ endfacet
+ facet normal -8.478980e-02  3.918806e-02  9.956279e-01
+   outer loop
+     vertex -2.790418e+00  2.861386e+00  3.779777e+01
+     vertex -2.500000e+01  5.565913e+00  3.579991e+01
+     vertex -2.500000e+01 -2.734876e+00  3.612663e+01
+   endloop
+ endfacet
+ facet normal  5.980107e-02  1.889685e-01  9.801606e-01
+   outer loop
+     vertex -2.790418e+00  1.139572e+01  3.615241e+01
+     vertex -2.790418e+00  2.861386e+00  3.779777e+01
+     vertex  2.500000e+01  1.089188e+01  3.455401e+01
+   endloop
+ endfacet
+ facet normal -8.478983e-02  2.649414e-01  9.605294e-01
+   outer loop
+     vertex -2.790418e+00  1.139572e+01  3.615241e+01
+     vertex -2.500000e+01  1.357408e+01  3.359103e+01
+     vertex -2.500000e+01  5.565913e+00  3.579991e+01
+   endloop
+ endfacet
+ facet normal -6.513741e-02  1.889053e-01  9.798326e-01
+   outer loop
+     vertex -2.790418e+00  1.139572e+01  3.615241e+01
+     vertex -2.500000e+01  5.565913e+00  3.579991e+01
+     vertex -2.790418e+00  2.861386e+00  3.779777e+01
+   endloop
+ endfacet
+ facet normal  5.980110e-02  4.072614e-01  9.113517e-01
+   outer loop
+     vertex -2.790418e+00  1.933093e+01  3.260635e+01
+     vertex -2.790418e+00  1.139572e+01  3.615241e+01
+     vertex  2.500000e+01  1.089188e+01  3.455401e+01
+   endloop
+ endfacet
+ facet normal -6.513745e-02  4.071251e-01  9.110468e-01
+   outer loop
+     vertex -2.790418e+00  1.933093e+01  3.260635e+01
+     vertex -2.500000e+01  1.357408e+01  3.359103e+01
+     vertex -2.790418e+00  1.139572e+01  3.615241e+01
+   endloop
+ endfacet
+ facet normal  5.980108e-02  4.072613e-01  9.113518e-01
+   outer loop
+     vertex -2.790418e+00  1.933093e+01  3.260635e+01
+     vertex  2.500000e+01  1.089188e+01  3.455401e+01
+     vertex  2.500000e+01  1.847626e+01  3.116474e+01
+   endloop
+ endfacet
+ facet normal -8.478983e-02  4.767655e-01  8.749316e-01
+   outer loop
+     vertex -2.790418e+00  1.933093e+01  3.260635e+01
+     vertex -2.500000e+01  2.086860e+01  2.961612e+01
+     vertex -2.500000e+01  1.357408e+01  3.359103e+01
+   endloop
+ endfacet
+ facet normal  5.980111e-02  6.041427e-01  7.946291e-01
+   outer loop
+     vertex -2.790418e+00  2.624983e+01  2.734603e+01
+     vertex -2.790418e+00  1.933093e+01  3.260635e+01
+     vertex  2.500000e+01  1.847626e+01  3.116474e+01
+   endloop
+ endfacet
+ facet normal  5.980102e-02  6.041425e-01  7.946293e-01
+   outer loop
+     vertex -2.790418e+00  2.624983e+01  2.734603e+01
+     vertex  2.500000e+01  1.847626e+01  3.116474e+01
+     vertex  2.500000e+01  2.508925e+01  2.613699e+01
+   endloop
+ endfacet
+ facet normal  5.980102e-02  7.692614e-01  6.361295e-01
+   outer loop
+     vertex -2.790418e+00  2.624983e+01  2.734603e+01
+     vertex  2.500000e+01  2.508925e+01  2.613699e+01
+     vertex  2.500000e+01  3.038320e+01  1.973511e+01
+   endloop
+ endfacet
+ facet normal -6.513743e-02  6.039406e-01  7.943632e-01
+   outer loop
+     vertex -2.790418e+00  2.624983e+01  2.734603e+01
+     vertex -2.500000e+01  2.086860e+01  2.961612e+01
+     vertex -2.790418e+00  1.933093e+01  3.260635e+01
+   endloop
+ endfacet
+ facet normal -8.478976e-02  6.635239e-01  7.433349e-01
+   outer loop
+     vertex -2.790418e+00  2.624983e+01  2.734603e+01
+     vertex -2.500000e+01  2.706597e+01  2.408415e+01
+     vertex -2.500000e+01  2.086860e+01  2.961612e+01
+   endloop
+ endfacet
+ facet normal -8.478965e-02  8.153981e-01  5.726575e-01
+   outer loop
+     vertex -2.790418e+00  3.178866e+01  2.064801e+01
+     vertex -2.500000e+01  3.184035e+01  1.728598e+01
+     vertex -2.500000e+01  2.706597e+01  2.408415e+01
+   endloop
+ endfacet
+ facet normal -6.513731e-02  7.690042e-01  6.359164e-01
+   outer loop
+     vertex -2.790418e+00  3.178866e+01  2.064801e+01
+     vertex -2.500000e+01  2.706597e+01  2.408415e+01
+     vertex -2.790418e+00  2.624983e+01  2.734603e+01
+   endloop
+ endfacet
+ facet normal  5.980093e-02  7.692616e-01  6.361292e-01
+   outer loop
+     vertex -2.790418e+00  3.178866e+01  2.064801e+01
+     vertex -2.790418e+00  2.624983e+01  2.734603e+01
+     vertex  2.500000e+01  3.038320e+01  1.973511e+01
+   endloop
+ endfacet
+ facet normal  5.980091e-02  8.939370e-01  4.441852e-01
+   outer loop
+     vertex -2.790418e+00  3.565621e+01  1.286443e+01
+     vertex  2.500000e+01  3.038320e+01  1.973511e+01
+     vertex  2.500000e+01  3.407976e+01  1.229566e+01
+   endloop
+ endfacet
+ facet normal  5.980089e-02  9.716142e-01  2.288880e-01
+   outer loop
+     vertex -2.790418e+00  3.565621e+01  1.286443e+01
+     vertex  2.500000e+01  3.407976e+01  1.229566e+01
+     vertex  2.500000e+01  3.598459e+01  4.209776e+00
+   endloop
+ endfacet
+ facet normal -6.513719e-02  8.936379e-01  4.440366e-01
+   outer loop
+     vertex -2.790418e+00  3.565621e+01  1.286443e+01
+     vertex -2.500000e+01  3.184035e+01  1.728598e+01
+     vertex -2.790418e+00  3.178866e+01  2.064801e+01
+   endloop
+ endfacet
+ facet normal -8.478963e-02  9.244033e-01  3.718727e-01
+   outer loop
+     vertex -2.790418e+00  3.565621e+01  1.286443e+01
+     vertex -2.500000e+01  3.494075e+01  9.579001e+00
+     vertex -2.500000e+01  3.184035e+01  1.728598e+01
+   endloop
+ endfacet
+ facet normal  5.980091e-02  8.939370e-01  4.441852e-01
+   outer loop
+     vertex -2.790418e+00  3.565621e+01  1.286443e+01
+     vertex -2.790418e+00  3.178866e+01  2.064801e+01
+     vertex  2.500000e+01  3.038320e+01  1.973511e+01
+   endloop
+ endfacet
+ facet normal  5.980103e-02  9.716141e-01  2.288884e-01
+   outer loop
+     vertex -2.790418e+00  3.764916e+01  4.404512e+00
+     vertex -2.790418e+00  3.565621e+01  1.286443e+01
+     vertex  2.500000e+01  3.598459e+01  4.209776e+00
+   endloop
+ endfacet
+ facet normal -8.478977e-02  9.848083e-01  1.515368e-01
+   outer loop
+     vertex -2.790418e+00  3.764916e+01  4.404512e+00
+     vertex -2.500000e+01  3.620415e+01  1.368415e+00
+     vertex -2.500000e+01  3.494075e+01  9.579001e+00
+   endloop
+ endfacet
+ facet normal -6.513723e-02  9.712890e-01  2.288118e-01
+   outer loop
+     vertex -2.790418e+00  3.764916e+01  4.404512e+00
+     vertex -2.500000e+01  3.494075e+01  9.579001e+00
+     vertex -2.790418e+00  3.565621e+01  1.286443e+01
+   endloop
+ endfacet
+ facet normal -6.513743e-02  9.978751e-01  1.557374e-03
+   outer loop
+     vertex -2.790418e+00  3.766273e+01 -4.286974e+00
+     vertex -2.500000e+01  3.620415e+01  1.368415e+00
+     vertex -2.790418e+00  3.764916e+01  4.404512e+00
+   endloop
+ endfacet
+ facet normal  5.980119e-02  9.982091e-01  1.557348e-03
+   outer loop
+     vertex -2.790418e+00  3.766273e+01 -4.286974e+00
+     vertex  2.500000e+01  3.598459e+01  4.209776e+00
+     vertex  2.500000e+01  3.599755e+01 -4.097435e+00
+   endloop
+ endfacet
+ facet normal  5.980118e-02  9.723238e-01 -2.258545e-01
+   outer loop
+     vertex -2.790418e+00  3.766273e+01 -4.286974e+00
+     vertex  2.500000e+01  3.599755e+01 -4.097435e+00
+     vertex  2.500000e+01  3.411796e+01 -1.218922e+01
+   endloop
+ endfacet
+ facet normal -8.478994e-02  9.934373e-01 -7.676561e-02
+   outer loop
+     vertex -2.790418e+00  3.766273e+01 -4.286974e+00
+     vertex -2.500000e+01  3.556413e+01 -6.914115e+00
+     vertex -2.500000e+01  3.620415e+01  1.368415e+00
+   endloop
+ endfacet
+ facet normal  5.980102e-02  9.982091e-01  1.557895e-03
+   outer loop
+     vertex -2.790418e+00  3.766273e+01 -4.286974e+00
+     vertex -2.790418e+00  3.764916e+01  4.404512e+00
+     vertex  2.500000e+01  3.598459e+01  4.209776e+00
+   endloop
+ endfacet
+ facet normal -8.478994e-02  9.498372e-01 -3.010316e-01
+   outer loop
+     vertex -2.790418e+00  3.569620e+01 -1.275307e+01
+     vertex -2.500000e+01  3.305436e+01 -1.483314e+01
+     vertex -2.500000e+01  3.556413e+01 -6.914115e+00
+   endloop
+ endfacet
+ facet normal  5.980119e-02  9.723238e-01 -2.258545e-01
+   outer loop
+     vertex -2.790418e+00  3.569620e+01 -1.275307e+01
+     vertex -2.790418e+00  3.766273e+01 -4.286974e+00
+     vertex  2.500000e+01  3.411796e+01 -1.218922e+01
+   endloop
+ endfacet
+ facet normal -6.513759e-02  9.719984e-01 -2.257789e-01
+   outer loop
+     vertex -2.790418e+00  3.569620e+01 -1.275307e+01
+     vertex -2.500000e+01  3.556413e+01 -6.914115e+00
+     vertex -2.790418e+00  3.766273e+01 -4.286974e+00
+   endloop
+ endfacet
+ facet normal -8.478975e-02  8.563000e-01 -5.094712e-01
+   outer loop
+     vertex -2.790418e+00  3.185295e+01 -2.054869e+01
+     vertex -2.500000e+01  2.880677e+01 -2.197232e+01
+     vertex -2.500000e+01  3.305436e+01 -1.483314e+01
+   endloop
+ endfacet
+ facet normal -6.513751e-02  8.950195e-01 -4.412450e-01
+   outer loop
+     vertex -2.790418e+00  3.185295e+01 -2.054869e+01
+     vertex -2.500000e+01  3.305436e+01 -1.483314e+01
+     vertex -2.790418e+00  3.569620e+01 -1.275307e+01
+   endloop
+ endfacet
+ facet normal -8.478962e-02  7.177430e-01 -6.911264e-01
+   outer loop
+     vertex -2.790418e+00  2.633506e+01 -2.726397e+01
+     vertex -2.500000e+01  2.304469e+01 -2.795632e+01
+     vertex -2.500000e+01  2.880677e+01 -2.197232e+01
+   endloop
+ endfacet
+ facet normal -6.513727e-02  7.709854e-01 -6.335129e-01
+   outer loop
+     vertex -2.790418e+00  2.633506e+01 -2.726397e+01
+     vertex -2.500000e+01  2.880677e+01 -2.197232e+01
+     vertex -2.790418e+00  3.185295e+01 -2.054869e+01
+   endloop
+ endfacet
+ facet normal -8.478975e-02  5.414505e-01 -8.364461e-01
+   outer loop
+     vertex -2.790418e+00  1.943262e+01 -3.254586e+01
+     vertex -2.500000e+01  1.607102e+01 -3.247053e+01
+     vertex -2.500000e+01  2.304469e+01 -2.795632e+01
+   endloop
+ endfacet
+ facet normal -6.513720e-02  6.064172e-01 -7.924742e-01
+   outer loop
+     vertex -2.790418e+00  1.943262e+01 -3.254586e+01
+     vertex -2.500000e+01  2.304469e+01 -2.795632e+01
+     vertex -2.790418e+00  2.633506e+01 -2.726397e+01
+   endloop
+ endfacet
+ facet normal -7.502332e-02  7.682552e-02 -9.942180e-01
+   outer loop
+     vertex -2.790418e+00  5.823386e+00 -3.745594e+01
+     vertex -2.790418e+00 -1.894995e-15 -3.790593e+01
+     vertex -2.500000e+01  9.217895e-15 -3.623000e+01
+   endloop
+ endfacet
+ facet normal -8.459078e-02  1.142349e-01 -9.898458e-01
+   outer loop
+     vertex -2.790418e+00  5.823386e+00 -3.745594e+01
+     vertex -2.500000e+01  9.217895e-15 -3.623000e+01
+     vertex -2.500000e+01  8.252439e+00 -3.527761e+01
+   endloop
+ endfacet
+ facet normal -5.526972e-02  3.373925e-01 -9.397401e-01
+   outer loop
+     vertex -2.790418e+00  5.823386e+00 -3.745594e+01
+     vertex -2.500000e+01  8.252439e+00 -3.527761e+01
+     vertex -2.500000e+01  1.607102e+01 -3.247053e+01
+   endloop
+ endfacet
+ facet normal -5.447693e-02  3.388739e-01 -9.392533e-01
+   outer loop
+     vertex -2.790418e+00  5.823386e+00 -3.745594e+01
+     vertex -2.500000e+01  1.607102e+01 -3.247053e+01
+     vertex -2.790418e+00  1.943262e+01 -3.254586e+01
+   endloop
+ endfacet
+ facet normal  9.729911e-02 -9.885549e-02 -9.903335e-01
+   outer loop
+     vertex  1.809526e+01 -8.436920e+00 -3.606620e+01
+     vertex  1.115216e+01 -4.749220e-15 -3.759053e+01
+     vertex  2.500000e+01 -1.626709e-09 -3.623000e+01
+   endloop
+ endfacet
+ facet normal  1.157367e-01 -1.138748e-01 -9.867307e-01
+   outer loop
+     vertex  1.809526e+01 -8.436920e+00 -3.606620e+01
+     vertex  2.500000e+01 -1.626709e-09 -3.623000e+01
+     vertex  2.500000e+01 -8.252439e+00 -3.527761e+01
+   endloop
+ endfacet
+ facet normal  1.157369e-01 -3.356383e-01 -9.348540e-01
+   outer loop
+     vertex  1.809526e+01 -8.436920e+00 -3.606620e+01
+     vertex  2.500000e+01 -8.252439e+00 -3.527761e+01
+     vertex  2.500000e+01 -1.607102e+01 -3.247053e+01
+   endloop
+ endfacet
+ facet normal  2.243039e-02 -1.276301e-01 -9.915682e-01
+   outer loop
+     vertex  1.115216e+01 -9.519247e+00 -3.636526e+01
+     vertex -2.790418e+00 -1.894995e-15 -3.790593e+01
+     vertex  1.115216e+01 -4.749220e-15 -3.759053e+01
+   endloop
+ endfacet
+ facet normal  6.249803e-02 -1.274126e-01 -9.898788e-01
+   outer loop
+     vertex  1.115216e+01 -9.519247e+00 -3.636526e+01
+     vertex  1.115216e+01 -4.749220e-15 -3.759053e+01
+     vertex  1.809526e+01 -8.436920e+00 -3.606620e+01
+   endloop
+ endfacet
+ facet normal  4.300798e-03 -1.536258e-01 -9.881197e-01
+   outer loop
+     vertex  1.115216e+01 -9.519247e+00 -3.636526e+01
+     vertex -2.790418e+00 -1.150851e+01 -3.611667e+01
+     vertex -2.790418e+00 -1.894995e-15 -3.790593e+01
+   endloop
+ endfacet
+ facet normal -6.317222e-02 -4.775330e-01 -8.763398e-01
+   outer loop
+     vertex  6.509329e+00 -1.765588e+01 -3.343724e+01
+     vertex -2.790418e+00 -2.411068e+01 -2.924952e+01
+     vertex -2.790418e+00 -1.150851e+01 -3.611667e+01
+   endloop
+ endfacet
+ facet normal  3.407634e-02 -3.555611e-01 -9.340316e-01
+   outer loop
+     vertex  6.509329e+00 -1.765588e+01 -3.343724e+01
+     vertex -2.790418e+00 -1.150851e+01 -3.611667e+01
+     vertex  1.115216e+01 -9.519247e+00 -3.636526e+01
+   endloop
+ endfacet
+ facet normal  1.019757e-01  2.281034e-01 -9.682819e-01
+   outer loop
+     vertex  1.115216e+01  1.046960e+01 -3.610312e+01
+     vertex  2.500000e+01  1.099968e+01 -3.451985e+01
+     vertex  2.500000e+01  5.565912e+00 -3.579991e+01
+   endloop
+ endfacet
+ facet normal  7.130468e-02  1.402988e-01 -9.875383e-01
+   outer loop
+     vertex  1.115216e+01  1.046960e+01 -3.610312e+01
+     vertex  2.500000e+01  5.565912e+00 -3.579991e+01
+     vertex  1.115216e+01 -4.749220e-15 -3.759053e+01
+   endloop
+ endfacet
+ facet normal  5.058386e-02  1.404768e-01 -9.887910e-01
+   outer loop
+     vertex  4.185329e+00  1.007215e+01 -3.651599e+01
+     vertex  1.115216e+01  1.046960e+01 -3.610312e+01
+     vertex  1.115216e+01 -4.749220e-15 -3.759053e+01
+   endloop
+ endfacet
+ facet normal -5.450723e-02  3.551875e-01 -9.332046e-01
+   outer loop
+     vertex  1.860337e+00  8.675262e+00 -3.691186e+01
+     vertex -2.790418e+00  1.943262e+01 -3.254586e+01
+     vertex  4.185329e+00  1.007215e+01 -3.651599e+01
+   endloop
+ endfacet
+ facet normal  7.387377e-02  1.561778e-01 -9.849625e-01
+   outer loop
+     vertex  1.860337e+00  8.675262e+00 -3.691186e+01
+     vertex  4.185329e+00  1.007215e+01 -3.651599e+01
+     vertex  1.115216e+01 -4.749220e-15 -3.759053e+01
+   endloop
+ endfacet
+ facet normal  2.249762e-02  1.018996e-01 -9.945403e-01
+   outer loop
+     vertex  1.860337e+00  8.675262e+00 -3.691186e+01
+     vertex  1.115216e+01 -4.749220e-15 -3.759053e+01
+     vertex -2.790418e+00 -1.894995e-15 -3.790593e+01
+   endloop
+ endfacet
+ facet normal  6.922956e-02  7.685780e-02 -9.946357e-01
+   outer loop
+     vertex  1.860337e+00  8.675262e+00 -3.691186e+01
+     vertex -2.790418e+00 -1.894995e-15 -3.790593e+01
+     vertex -2.790418e+00  5.823386e+00 -3.745594e+01
+   endloop
+ endfacet
+ facet normal -9.759704e-02  3.377577e-01 -9.361595e-01
+   outer loop
+     vertex  1.860337e+00  8.675262e+00 -3.691186e+01
+     vertex -2.790418e+00  5.823386e+00 -3.745594e+01
+     vertex -2.790418e+00  1.943262e+01 -3.254586e+01
+   endloop
+ endfacet
+ facet normal  1.151676e-01 -7.155439e-01 -6.890089e-01
+   outer loop
+     vertex  1.578444e+01 -2.406987e+01 -2.843203e+01
+     vertex  2.500000e+01 -2.304469e+01 -2.795632e+01
+     vertex  2.500000e+01 -2.880677e+01 -2.197232e+01
+   endloop
+ endfacet
+ facet normal  4.144890e-03 -7.274541e-01 -6.861439e-01
+   outer loop
+     vertex  1.860337e+00 -2.449971e+01 -2.893977e+01
+     vertex  9.605503e+00 -2.635625e+01 -2.692466e+01
+     vertex -2.790418e+00 -3.013931e+01 -2.298872e+01
+   endloop
+ endfacet
+ facet normal  9.166637e-03 -5.535047e-01 -8.327956e-01
+   outer loop
+     vertex  1.860337e+00 -2.449971e+01 -2.893977e+01
+     vertex -2.790418e+00 -2.411068e+01 -2.924952e+01
+     vertex  6.509329e+00 -1.765588e+01 -3.343724e+01
+   endloop
+ endfacet
+ facet normal  7.155508e-02 -5.812711e-01 -8.105577e-01
+   outer loop
+     vertex  1.860337e+00 -2.449971e+01 -2.893977e+01
+     vertex  6.509329e+00 -1.765588e+01 -3.343724e+01
+     vertex  9.605503e+00 -2.635625e+01 -2.692466e+01
+   endloop
+ endfacet
+ facet normal -1.405635e-02 -7.202656e-01 -6.935559e-01
+   outer loop
+     vertex  1.860337e+00 -2.449971e+01 -2.893977e+01
+     vertex -2.790418e+00 -3.013931e+01 -2.298872e+01
+     vertex -2.790418e+00 -2.411068e+01 -2.924952e+01
+   endloop
+ endfacet
+ facet normal  1.073722e-01  6.041943e-01 -7.895698e-01
+   outer loop
+     vertex  1.809526e+01  1.856998e+01 -3.204853e+01
+     vertex  2.500000e+01  2.517072e+01 -2.605855e+01
+     vertex  2.500000e+01  1.857345e+01 -3.110691e+01
+   endloop
+ endfacet
+ facet normal  1.231803e-01  4.077100e-01 -9.047647e-01
+   outer loop
+     vertex  1.809526e+01  1.856998e+01 -3.204853e+01
+     vertex  2.500000e+01  1.857345e+01 -3.110691e+01
+     vertex  2.500000e+01  1.099968e+01 -3.451985e+01
+   endloop
+ endfacet
+ facet normal  9.047515e-02  3.826720e-01 -9.194435e-01
+   outer loop
+     vertex  1.809526e+01  1.856998e+01 -3.204853e+01
+     vertex  2.500000e+01  1.099968e+01 -3.451985e+01
+     vertex  1.115216e+01  1.046960e+01 -3.610312e+01
+   endloop
+ endfacet
+ facet normal  2.594289e-02  4.295816e-01 -9.026553e-01
+   outer loop
+     vertex  1.115216e+01  2.141497e+01 -3.089412e+01
+     vertex  1.809526e+01  1.856998e+01 -3.204853e+01
+     vertex  1.115216e+01  1.046960e+01 -3.610312e+01
+   endloop
+ endfacet
+ facet normal -5.820006e-03  3.867833e-01 -9.221523e-01
+   outer loop
+     vertex  4.185329e+00  1.899099e+01 -3.277512e+01
+     vertex  4.185329e+00  1.007215e+01 -3.651599e+01
+     vertex -2.790418e+00  1.943262e+01 -3.254586e+01
+   endloop
+ endfacet
+ facet normal  9.386054e-02  4.278291e-01 -8.989730e-01
+   outer loop
+     vertex  4.185329e+00  1.899099e+01 -3.277512e+01
+     vertex  1.115216e+01  2.141497e+01 -3.089412e+01
+     vertex  1.115216e+01  1.046960e+01 -3.610312e+01
+   endloop
+ endfacet
+ facet normal  3.256653e-02  3.865847e-01 -9.216788e-01
+   outer loop
+     vertex  4.185329e+00  1.899099e+01 -3.277512e+01
+     vertex  1.115216e+01  1.046960e+01 -3.610312e+01
+     vertex  4.185329e+00  1.007215e+01 -3.651599e+01
+   endloop
+ endfacet
+ facet normal  1.237210e-02  6.076612e-01 -7.941000e-01
+   outer loop
+     vertex  4.185329e+00  1.899099e+01 -3.277512e+01
+     vertex -2.790418e+00  1.943262e+01 -3.254586e+01
+     vertex -2.790418e+00  2.633506e+01 -2.726397e+01
+   endloop
+ endfacet
+ facet normal  9.322442e-02 -3.394064e-01 -9.360088e-01
+   outer loop
+     vertex  1.694035e+01 -1.669695e+01 -3.318606e+01
+     vertex  1.115216e+01 -9.519247e+00 -3.636526e+01
+     vertex  1.809526e+01 -8.436920e+00 -3.606620e+01
+   endloop
+ endfacet
+ facet normal  1.159421e-01 -5.397426e-01 -8.338077e-01
+   outer loop
+     vertex  1.694035e+01 -1.669695e+01 -3.318606e+01
+     vertex  2.500000e+01 -1.607102e+01 -3.247053e+01
+     vertex  2.500000e+01 -2.304469e+01 -2.795632e+01
+   endloop
+ endfacet
+ facet normal  1.093681e-01 -3.408682e-01 -9.337277e-01
+   outer loop
+     vertex  1.694035e+01 -1.669695e+01 -3.318606e+01
+     vertex  1.809526e+01 -8.436920e+00 -3.606620e+01
+     vertex  2.500000e+01 -1.607102e+01 -3.247053e+01
+   endloop
+ endfacet
+ facet normal  1.039944e-01 -5.504365e-01 -8.283748e-01
+   outer loop
+     vertex  1.694035e+01 -1.669695e+01 -3.318606e+01
+     vertex  2.500000e+01 -2.304469e+01 -2.795632e+01
+     vertex  1.578444e+01 -2.406987e+01 -2.843203e+01
+   endloop
+ endfacet
+ facet normal  6.704934e-02 -3.583704e-01 -9.311686e-01
+   outer loop
+     vertex  1.346989e+01 -1.726266e+01 -3.321823e+01
+     vertex  1.115216e+01 -9.519247e+00 -3.636526e+01
+     vertex  1.694035e+01 -1.669695e+01 -3.318606e+01
+   endloop
+ endfacet
+ facet normal  4.979260e-02 -3.632130e-01 -9.303747e-01
+   outer loop
+     vertex  1.346989e+01 -1.726266e+01 -3.321823e+01
+     vertex  6.509329e+00 -1.765588e+01 -3.343724e+01
+     vertex  1.115216e+01 -9.519247e+00 -3.636526e+01
+   endloop
+ endfacet
+ facet normal  1.180952e-02 -5.724369e-01 -8.198637e-01
+   outer loop
+     vertex  1.346989e+01 -1.726266e+01 -3.321823e+01
+     vertex  1.578444e+01 -2.406987e+01 -2.843203e+01
+     vertex  9.605503e+00 -2.635625e+01 -2.692466e+01
+   endloop
+ endfacet
+ facet normal  9.735494e-02 -5.500717e-01 -8.294234e-01
+   outer loop
+     vertex  1.346989e+01 -1.726266e+01 -3.321823e+01
+     vertex  1.694035e+01 -1.669695e+01 -3.318606e+01
+     vertex  1.578444e+01 -2.406987e+01 -2.843203e+01
+   endloop
+ endfacet
+ facet normal  5.849354e-02 -5.848016e-01 -8.090646e-01
+   outer loop
+     vertex  1.346989e+01 -1.726266e+01 -3.321823e+01
+     vertex  9.605503e+00 -2.635625e+01 -2.692466e+01
+     vertex  6.509329e+00 -1.765588e+01 -3.343724e+01
+   endloop
+ endfacet
+ facet normal  1.126230e-01 -8.539272e-01 -5.080595e-01
+   outer loop
+     vertex  1.063673e+01 -3.214014e+01 -1.955368e+01
+     vertex  2.500000e+01 -2.880677e+01 -2.197232e+01
+     vertex  2.500000e+01 -3.305436e+01 -1.483314e+01
+   endloop
+ endfacet
+ facet normal  3.858822e-02 -9.525600e-01 -3.018946e-01
+   outer loop
+     vertex  1.063673e+01 -3.214014e+01 -1.955368e+01
+     vertex  2.500000e+01 -3.305436e+01 -1.483314e+01
+     vertex  2.500000e+01 -3.556413e+01 -6.914116e+00
+   endloop
+ endfacet
+ facet normal  8.240289e-02 -9.500280e-01 -3.010923e-01
+   outer loop
+     vertex  1.063673e+01 -3.214014e+01 -1.955368e+01
+     vertex -2.790418e+00 -3.720926e+01 -7.233949e+00
+     vertex -2.790418e+00 -3.458339e+01 -1.551929e+01
+   endloop
+ endfacet
+ facet normal  1.330866e-01 -7.705863e-01 -6.232855e-01
+   outer loop
+     vertex  1.063673e+01 -3.214014e+01 -1.955368e+01
+     vertex  9.605503e+00 -2.635625e+01 -2.692466e+01
+     vertex  1.578444e+01 -2.406987e+01 -2.843203e+01
+   endloop
+ endfacet
+ facet normal  4.201672e-02 -7.831542e-01 -6.204063e-01
+   outer loop
+     vertex  1.063673e+01 -3.214014e+01 -1.955368e+01
+     vertex -2.790418e+00 -3.013931e+01 -2.298872e+01
+     vertex  9.605503e+00 -2.635625e+01 -2.692466e+01
+   endloop
+ endfacet
+ facet normal  5.962569e-02 -9.443237e-01 -3.235698e-01
+   outer loop
+     vertex  1.063673e+01 -3.214014e+01 -1.955368e+01
+     vertex  2.500000e+01 -3.556413e+01 -6.914116e+00
+     vertex -2.790418e+00 -3.720926e+01 -7.233949e+00
+   endloop
+ endfacet
+ facet normal  6.629912e-02 -7.571848e-01 -6.498274e-01
+   outer loop
+     vertex  1.063673e+01 -3.214014e+01 -1.955368e+01
+     vertex  1.578444e+01 -2.406987e+01 -2.843203e+01
+     vertex  2.500000e+01 -2.880677e+01 -2.197232e+01
+   endloop
+ endfacet
+ facet normal  2.746839e-03 -8.593912e-01 -5.113112e-01
+   outer loop
+     vertex  1.063673e+01 -3.214014e+01 -1.955368e+01
+     vertex -2.790418e+00 -3.458339e+01 -1.551929e+01
+     vertex -2.790418e+00 -3.013931e+01 -2.298872e+01
+   endloop
+ endfacet
+ facet normal  1.504152e-01  6.642096e-01 -7.322574e-01
+   outer loop
+     vertex  1.115216e+01  2.866566e+01 -2.431723e+01
+     vertex  1.809526e+01  1.856998e+01 -3.204853e+01
+     vertex  1.115216e+01  2.141497e+01 -3.089412e+01
+   endloop
+ endfacet
+ facet normal  3.410115e-02  8.964029e-01 -4.419264e-01
+   outer loop
+     vertex  1.115216e+01  2.866566e+01 -2.431723e+01
+     vertex  2.500000e+01  3.411796e+01 -1.218922e+01
+     vertex  2.500000e+01  3.044465e+01 -1.964017e+01
+   endloop
+ endfacet
+ facet normal  1.144089e-01  7.675533e-01 -6.306921e-01
+   outer loop
+     vertex  1.115216e+01  2.866566e+01 -2.431723e+01
+     vertex  2.500000e+01  3.044465e+01 -1.964017e+01
+     vertex  2.500000e+01  2.517072e+01 -2.605855e+01
+   endloop
+ endfacet
+ facet normal  5.721132e-02  6.334293e-01 -7.716827e-01
+   outer loop
+     vertex  1.115216e+01  2.866566e+01 -2.431723e+01
+     vertex  4.185329e+00  1.899099e+01 -3.277512e+01
+     vertex -2.790418e+00  2.633506e+01 -2.726397e+01
+   endloop
+ endfacet
+ facet normal -3.376106e-02  6.714704e-01 -7.402619e-01
+   outer loop
+     vertex  1.115216e+01  2.866566e+01 -2.431723e+01
+     vertex  1.115216e+01  2.141497e+01 -3.089412e+01
+     vertex  4.185329e+00  1.899099e+01 -3.277512e+01
+   endloop
+ endfacet
+ facet normal  6.299677e-02  6.337404e-01 -7.709763e-01
+   outer loop
+     vertex  1.115216e+01  2.866566e+01 -2.431723e+01
+     vertex  2.500000e+01  2.517072e+01 -2.605855e+01
+     vertex  1.809526e+01  1.856998e+01 -3.204853e+01
+   endloop
+ endfacet
+ facet normal  8.520903e-02  8.936623e-01 -4.405759e-01
+   outer loop
+     vertex  1.115216e+01  2.866566e+01 -2.431723e+01
+     vertex -2.790418e+00  3.185295e+01 -2.054869e+01
+     vertex -2.790418e+00  3.569620e+01 -1.275307e+01
+   endloop
+ endfacet
+ facet normal  5.959658e-02  8.832395e-01 -4.651195e-01
+   outer loop
+     vertex  1.115216e+01  2.866566e+01 -2.431723e+01
+     vertex -2.790418e+00  3.569620e+01 -1.275307e+01
+     vertex  2.500000e+01  3.411796e+01 -1.218922e+01
+   endloop
+ endfacet
+ facet normal  5.026519e-03  7.726165e-01 -6.348531e-01
+   outer loop
+     vertex  1.115216e+01  2.866566e+01 -2.431723e+01
+     vertex -2.790418e+00  2.633506e+01 -2.726397e+01
+     vertex -2.790418e+00  3.185295e+01 -2.054869e+01
+   endloop
+ endfacet
+ facet normal  1.543579e-01 -1.132711e-01 -9.815005e-01
+   outer loop
+     vertex  2.500000e+01 -8.252439e+00 -3.527761e+01
+     vertex  2.500000e+01 -1.626709e-09 -3.623000e+01
+     vertex  5.997501e+01 -2.677751e-15 -3.072957e+01
+   endloop
+ endfacet
+ facet normal  1.549071e-01  7.611190e-02 -9.849928e-01
+   outer loop
+     vertex  2.500000e+01 -1.626709e-09 -3.623000e+01
+     vertex  2.500000e+01  5.565912e+00 -3.579991e+01
+     vertex  5.997501e+01 -2.677751e-15 -3.072957e+01
+   endloop
+ endfacet
+ facet normal  8.563601e-01 -1.176205e-01 -5.028049e-01
+   outer loop
+     vertex  1.319141e+02 -2.236903e+00 -4.519526e+00
+     vertex  1.319141e+02 -1.654553e-15 -5.042802e+00
+     vertex  1.329051e+02 -1.147442e-15 -3.354896e+00
+   endloop
+ endfacet
+ facet normal  7.624719e-01 -1.473781e-01 -6.300129e-01
+   outer loop
+     vertex  1.319141e+02 -2.236903e+00 -4.519526e+00
+     vertex  1.305169e+02 -2.114976e-15 -6.733768e+00
+     vertex  1.319141e+02 -1.654553e-15 -5.042802e+00
+   endloop
+ endfacet
+ facet normal  5.386145e-01 -1.919160e-01 -8.204039e-01
+   outer loop
+     vertex  1.228903e+02 -5.479613e+00 -1.107122e+01
+     vertex  1.228903e+02 -3.293760e-15 -1.235306e+01
+     vertex  1.280160e+02 -2.653589e-15 -8.987895e+00
+   endloop
+ endfacet
+ facet normal  4.095323e-01 -2.078021e-01 -8.883139e-01
+   outer loop
+     vertex  1.121276e+02 -7.680604e+00 -1.551819e+01
+     vertex  1.121276e+02 -3.860339e-15 -1.731491e+01
+     vertex  1.228903e+02 -3.293760e-15 -1.235306e+01
+   endloop
+ endfacet
+ facet normal  4.095323e-01 -2.078021e-01 -8.883139e-01
+   outer loop
+     vertex  1.121276e+02 -7.680604e+00 -1.551819e+01
+     vertex  1.228903e+02 -3.293760e-15 -1.235306e+01
+     vertex  1.228903e+02 -5.479613e+00 -1.107122e+01
+   endloop
+ endfacet
+ facet normal  4.095323e-01 -5.802804e-01 -7.039587e-01
+   outer loop
+     vertex  1.121276e+02 -1.376723e+01 -1.050093e+01
+     vertex  1.228903e+02 -5.479613e+00 -1.107122e+01
+     vertex  1.228903e+02 -9.822023e+00 -7.491731e+00
+   endloop
+ endfacet
+ facet normal  4.095323e-01 -5.802804e-01 -7.039587e-01
+   outer loop
+     vertex  1.121276e+02 -1.376723e+01 -1.050093e+01
+     vertex  1.121276e+02 -7.680604e+00 -1.551819e+01
+     vertex  1.228903e+02 -5.479613e+00 -1.107122e+01
+   endloop
+ endfacet
+ facet normal  4.095323e-01 -8.323309e-01 -3.735084e-01
+   outer loop
+     vertex  1.121276e+02 -1.699668e+01 -3.304369e+00
+     vertex  1.121276e+02 -1.376723e+01 -1.050093e+01
+     vertex  1.228903e+02 -9.822023e+00 -7.491731e+00
+   endloop
+ endfacet
+ facet normal  4.095323e-01 -8.323309e-01 -3.735084e-01
+   outer loop
+     vertex  1.121276e+02 -1.699668e+01 -3.304369e+00
+     vertex  1.228903e+02 -9.822023e+00 -7.491731e+00
+     vertex  1.228903e+02 -1.212603e+01 -2.357453e+00
+   endloop
+ endfacet
+ facet normal  4.095323e-01 -9.116447e-01  3.445756e-02
+   outer loop
+     vertex  1.121276e+02 -1.669875e+01  4.577960e+00
+     vertex  1.228903e+02 -1.212603e+01 -2.357453e+00
+     vertex  1.228903e+02 -1.191348e+01  3.266078e+00
+   endloop
+ endfacet
+ facet normal  4.095323e-01 -9.116447e-01  3.445756e-02
+   outer loop
+     vertex  1.121276e+02 -1.669875e+01  4.577960e+00
+     vertex  1.121276e+02 -1.699668e+01 -3.304369e+00
+     vertex  1.228903e+02 -1.212603e+01 -2.357453e+00
+   endloop
+ endfacet
+ facet normal  4.095323e-01 -8.017613e-01  4.352724e-01
+   outer loop
+     vertex  1.121276e+02 -1.293527e+01  1.151021e+01
+     vertex  1.121276e+02 -1.669875e+01  4.577960e+00
+     vertex  1.228903e+02 -1.191348e+01  3.266078e+00
+   endloop
+ endfacet
+ facet normal  4.095323e-01 -8.017613e-01  4.352724e-01
+   outer loop
+     vertex  1.121276e+02 -1.293527e+01  1.151021e+01
+     vertex  1.228903e+02 -1.191348e+01  3.266078e+00
+     vertex  1.228903e+02 -9.228474e+00  8.211787e+00
+   endloop
+ endfacet
+ facet normal  4.095323e-01 -5.254854e-01  7.457536e-01
+   outer loop
+     vertex  1.121276e+02 -6.487275e+00  1.605370e+01
+     vertex  1.228903e+02 -9.228474e+00  8.211787e+00
+     vertex  1.228903e+02 -4.628250e+00  1.145327e+01
+   endloop
+ endfacet
+ facet normal  4.095323e-01 -5.254854e-01  7.457536e-01
+   outer loop
+     vertex  1.121276e+02 -6.487275e+00  1.605370e+01
+     vertex  1.121276e+02 -1.293527e+01  1.151021e+01
+     vertex  1.228903e+02 -9.228474e+00  8.211787e+00
+   endloop
+ endfacet
+ facet normal  1.543580e-01 -3.338592e-01 -9.298987e-01
+   outer loop
+     vertex  5.997501e+01 -1.363112e+01 -2.754086e+01
+     vertex  2.500000e+01 -1.607102e+01 -3.247053e+01
+     vertex  2.500000e+01 -8.252439e+00 -3.527761e+01
+   endloop
+ endfacet
+ facet normal  1.543581e-01 -5.368946e-01 -8.294081e-01
+   outer loop
+     vertex  5.997501e+01 -1.363112e+01 -2.754086e+01
+     vertex  2.500000e+01 -2.304469e+01 -2.795632e+01
+     vertex  2.500000e+01 -1.607102e+01 -3.247053e+01
+   endloop
+ endfacet
+ facet normal  1.774997e-01 -2.241624e-01 -9.582511e-01
+   outer loop
+     vertex  5.997501e+01 -1.363112e+01 -2.754086e+01
+     vertex  2.500000e+01 -8.252439e+00 -3.527761e+01
+     vertex  5.997501e+01 -2.677751e-15 -3.072957e+01
+   endloop
+ endfacet
+ facet normal  4.095323e-01 -1.401535e-01  9.014656e-01
+   outer loop
+     vertex  1.121276e+02  1.307041e+00  1.726551e+01
+     vertex  1.121276e+02 -6.487275e+00  1.605370e+01
+     vertex  1.228903e+02 -4.628250e+00  1.145327e+01
+   endloop
+ endfacet
+ facet normal  4.095323e-01 -1.401535e-01  9.014656e-01
+   outer loop
+     vertex  1.121276e+02  1.307041e+00  1.726551e+01
+     vertex  1.228903e+02 -4.628250e+00  1.145327e+01
+     vertex  1.228903e+02  9.324889e-01  1.231782e+01
+   endloop
+ endfacet
+ facet normal  1.543581e-01 -7.117037e-01 -6.853112e-01
+   outer loop
+     vertex  5.997501e+01 -2.443334e+01 -1.863649e+01
+     vertex  2.500000e+01 -2.880677e+01 -2.197232e+01
+     vertex  2.500000e+01 -2.304469e+01 -2.795632e+01
+   endloop
+ endfacet
+ facet normal  1.543581e-01 -8.490949e-01 -5.051845e-01
+   outer loop
+     vertex  5.997501e+01 -2.443334e+01 -1.863649e+01
+     vertex  2.500000e+01 -3.305436e+01 -1.483314e+01
+     vertex  2.500000e+01 -2.880677e+01 -2.197232e+01
+   endloop
+ endfacet
+ facet normal  1.774999e-01 -6.259660e-01 -7.593815e-01
+   outer loop
+     vertex  5.997501e+01 -2.443334e+01 -1.863649e+01
+     vertex  2.500000e+01 -2.304469e+01 -2.795632e+01
+     vertex  5.997501e+01 -1.363112e+01 -2.754086e+01
+   endloop
+ endfacet
+ facet normal  4.095323e-01  2.742649e-01  8.700931e-01
+   outer loop
+     vertex  1.121276e+02  8.830104e+00  1.489414e+01
+     vertex  1.228903e+02  9.324889e-01  1.231782e+01
+     vertex  1.228903e+02  6.299706e+00  1.062600e+01
+   endloop
+ endfacet
+ facet normal  4.095323e-01  6.317642e-01  6.581469e-01
+   outer loop
+     vertex  1.121276e+02  8.830104e+00  1.489414e+01
+     vertex  1.228903e+02  6.299706e+00  1.062600e+01
+     vertex  1.228903e+02  1.035952e+01  6.728927e+00
+   endloop
+ endfacet
+ facet normal  4.095323e-01  2.742649e-01  8.700931e-01
+   outer loop
+     vertex  1.121276e+02  8.830104e+00  1.489414e+01
+     vertex  1.121276e+02  1.307041e+00  1.726551e+01
+     vertex  1.228903e+02  9.324889e-01  1.231782e+01
+   endloop
+ endfacet
+ facet normal  1.543579e-01 -9.418451e-01 -2.984987e-01
+   outer loop
+     vertex  5.997501e+01 -3.016480e+01 -5.864418e+00
+     vertex  2.500000e+01 -3.556413e+01 -6.914116e+00
+     vertex  2.500000e+01 -3.305436e+01 -1.483314e+01
+   endloop
+ endfacet
+ facet normal  1.543579e-01 -9.850784e-01 -7.611972e-02
+   outer loop
+     vertex  5.997501e+01 -3.016480e+01 -5.864418e+00
+     vertex  2.500000e+01 -3.620415e+01  1.368414e+00
+     vertex  2.500000e+01 -3.556413e+01 -6.914116e+00
+   endloop
+ endfacet
+ facet normal  1.774997e-01 -8.978605e-01 -4.029148e-01
+   outer loop
+     vertex  5.997501e+01 -3.016480e+01 -5.864418e+00
+     vertex  2.500000e+01 -3.305436e+01 -1.483314e+01
+     vertex  5.997501e+01 -2.443334e+01 -1.863649e+01
+   endloop
+ endfacet
+ facet normal  8.596865e-01  7.847618e-02 -5.047580e-01
+   outer loop
+     vertex  1.319141e+02  1.531030e+00 -4.804768e+00
+     vertex  1.329051e+02 -1.147442e-15 -3.354896e+00
+     vertex  1.319141e+02 -1.654553e-15 -5.042802e+00
+   endloop
+ endfacet
+ facet normal  7.671373e-01  9.854926e-02 -6.338678e-01
+   outer loop
+     vertex  1.319141e+02  1.531030e+00 -4.804768e+00
+     vertex  1.319141e+02 -1.654553e-15 -5.042802e+00
+     vertex  1.305169e+02 -2.114976e-15 -6.733768e+00
+   endloop
+ endfacet
+ facet normal  4.095323e-01  6.317642e-01  6.581469e-01
+   outer loop
+     vertex  1.121276e+02  1.452062e+01  9.431729e+00
+     vertex  1.121276e+02  8.830104e+00  1.489414e+01
+     vertex  1.228903e+02  1.035952e+01  6.728927e+00
+   endloop
+ endfacet
+ facet normal  1.543581e-01 -9.765219e-01  1.502617e-01
+   outer loop
+     vertex  5.997501e+01 -2.963605e+01  8.124719e+00
+     vertex  2.500000e+01 -3.494075e+01  9.579001e+00
+     vertex  2.500000e+01 -3.620415e+01  1.368414e+00
+   endloop
+ endfacet
+ facet normal  1.543581e-01 -9.166252e-01  3.687436e-01
+   outer loop
+     vertex  5.997501e+01 -2.963605e+01  8.124719e+00
+     vertex  2.500000e+01 -3.184036e+01  1.728598e+01
+     vertex  2.500000e+01 -3.494075e+01  9.579001e+00
+   endloop
+ endfacet
+ facet normal  1.774997e-01 -9.834186e-01  3.717041e-02
+   outer loop
+     vertex  5.997501e+01 -2.963605e+01  8.124719e+00
+     vertex  2.500000e+01 -3.620415e+01  1.368414e+00
+     vertex  5.997501e+01 -3.016480e+01 -5.864418e+00
+   endloop
+ endfacet
+ facet normal  4.095323e-01  8.581510e-01  3.096129e-01
+   outer loop
+     vertex  1.121276e+02  1.719762e+01  2.011920e+00
+     vertex  1.121276e+02  1.452062e+01  9.431729e+00
+     vertex  1.228903e+02  1.035952e+01  6.728927e+00
+   endloop
+ endfacet
+ facet normal  4.095323e-01  8.581510e-01  3.096129e-01
+   outer loop
+     vertex  1.121276e+02  1.719762e+01  2.011920e+00
+     vertex  1.228903e+02  1.035952e+01  6.728927e+00
+     vertex  1.228903e+02  1.226939e+01  1.435374e+00
+   endloop
+ endfacet
+ facet normal  1.543581e-01 -8.085372e-01  5.678390e-01
+   outer loop
+     vertex  5.997501e+01 -2.295682e+01  2.042770e+01
+     vertex  2.500000e+01 -2.706597e+01  2.408415e+01
+     vertex  2.500000e+01 -3.184036e+01  1.728598e+01
+   endloop
+ endfacet
+ facet normal  1.543581e-01 -6.579409e-01  7.370803e-01
+   outer loop
+     vertex  5.997501e+01 -2.295682e+01  2.042770e+01
+     vertex  2.500000e+01 -2.086860e+01  2.961612e+01
+     vertex  2.500000e+01 -2.706597e+01  2.408415e+01
+   endloop
+ endfacet
+ facet normal  1.774999e-01 -8.648841e-01  4.695415e-01
+   outer loop
+     vertex  5.997501e+01 -2.295682e+01  2.042770e+01
+     vertex  2.500000e+01 -3.184036e+01  1.728598e+01
+     vertex  5.997501e+01 -2.963605e+01  8.124719e+00
+   endloop
+ endfacet
+ facet normal  4.095323e-01  9.064425e-01 -1.031762e-01
+   outer loop
+     vertex  1.121276e+02  1.630553e+01 -5.825429e+00
+     vertex  1.121276e+02  1.719762e+01  2.011920e+00
+     vertex  1.228903e+02  1.226939e+01  1.435374e+00
+   endloop
+ endfacet
+ facet normal  4.095323e-01  7.666166e-01 -4.945527e-01
+   outer loop
+     vertex  1.121276e+02  1.630553e+01 -5.825429e+00
+     vertex  1.228903e+02  1.163294e+01 -4.156066e+00
+     vertex  1.228903e+02  8.582265e+00 -8.884982e+00
+   endloop
+ endfacet
+ facet normal  4.095323e-01  9.064425e-01 -1.031762e-01
+   outer loop
+     vertex  1.121276e+02  1.630553e+01 -5.825429e+00
+     vertex  1.228903e+02  1.226939e+01  1.435374e+00
+     vertex  1.228903e+02  1.163294e+01 -4.156066e+00
+   endloop
+ endfacet
+ facet normal  1.774998e-01 -5.668569e-01  8.044669e-01
+   outer loop
+     vertex  5.997501e+01 -1.151327e+01  2.849125e+01
+     vertex  2.500000e+01 -2.086860e+01  2.961612e+01
+     vertex  5.997501e+01 -2.295682e+01  2.042770e+01
+   endloop
+ endfacet
+ facet normal  1.543580e-01 -4.727539e-01  8.675698e-01
+   outer loop
+     vertex  5.997501e+01 -1.151327e+01  2.849125e+01
+     vertex  2.500000e+01 -1.357408e+01  3.359103e+01
+     vertex  2.500000e+01 -2.086860e+01  2.961612e+01
+   endloop
+ endfacet
+ facet normal  1.543580e-01 -2.627122e-01  9.524473e-01
+   outer loop
+     vertex  5.997501e+01 -1.151327e+01  2.849125e+01
+     vertex  2.500000e+01 -5.565915e+00  3.579991e+01
+     vertex  2.500000e+01 -1.357408e+01  3.359103e+01
+   endloop
+ endfacet
+ facet normal  4.095323e-01  7.666166e-01 -4.945527e-01
+   outer loop
+     vertex  1.121276e+02  1.202950e+01 -1.245380e+01
+     vertex  1.121276e+02  1.630553e+01 -5.825429e+00
+     vertex  1.228903e+02  8.582265e+00 -8.884982e+00
+   endloop
+ endfacet
+ facet normal  1.543580e-01 -3.885837e-02  9.872505e-01
+   outer loop
+     vertex  5.997501e+01  2.319666e+00  3.064189e+01
+     vertex  2.500000e+01  2.734875e+00  3.612663e+01
+     vertex  2.500000e+01 -5.565915e+00  3.579991e+01
+   endloop
+ endfacet
+ facet normal  1.543580e-01  1.870385e-01  9.701496e-01
+   outer loop
+     vertex  5.997501e+01  2.319666e+00  3.064189e+01
+     vertex  2.500000e+01  1.089188e+01  3.455401e+01
+     vertex  2.500000e+01  2.734875e+00  3.612663e+01
+   endloop
+ endfacet
+ facet normal  1.774997e-01 -1.511878e-01  9.724382e-01
+   outer loop
+     vertex  5.997501e+01  2.319666e+00  3.064189e+01
+     vertex  2.500000e+01 -5.565915e+00  3.579991e+01
+     vertex  5.997501e+01 -1.151327e+01  2.849125e+01
+   endloop
+ endfacet
+ facet normal  4.145598e-01  1.398042e-01 -8.992191e-01
+   outer loop
+     vertex  1.121276e+02  5.256928e+00 -1.649760e+01
+     vertex  1.228903e+02 -3.293760e-15 -1.235306e+01
+     vertex  1.121276e+02 -3.860339e-15 -1.731491e+01
+   endloop
+ endfacet
+ facet normal  4.145598e-01  1.398042e-01 -8.992191e-01
+   outer loop
+     vertex  1.121276e+02  5.256928e+00 -1.649760e+01
+     vertex  1.228903e+02  3.750477e+00 -1.176997e+01
+     vertex  1.228903e+02 -3.293760e-15 -1.235306e+01
+   endloop
+ endfacet
+ facet normal  4.095323e-01  4.676918e-01 -7.832929e-01
+   outer loop
+     vertex  1.121276e+02  5.256928e+00 -1.649760e+01
+     vertex  1.228903e+02  8.582265e+00 -8.884982e+00
+     vertex  1.228903e+02  3.750477e+00 -1.176997e+01
+   endloop
+ endfacet
+ facet normal  4.095323e-01  4.676918e-01 -7.832929e-01
+   outer loop
+     vertex  1.121276e+02  5.256928e+00 -1.649760e+01
+     vertex  1.121276e+02  1.202950e+01 -1.245380e+01
+     vertex  1.228903e+02  8.582265e+00 -8.884982e+00
+   endloop
+ endfacet
+ facet normal  1.543580e-01  4.031017e-01  9.020436e-01
+   outer loop
+     vertex  5.997501e+01  1.567120e+01  2.643331e+01
+     vertex  2.500000e+01  1.847626e+01  3.116474e+01
+     vertex  2.500000e+01  1.089188e+01  3.455401e+01
+   endloop
+ endfacet
+ facet normal  1.543580e-01  5.979720e-01  7.865132e-01
+   outer loop
+     vertex  5.997501e+01  1.567120e+01  2.643331e+01
+     vertex  2.500000e+01  2.508925e+01  2.613699e+01
+     vertex  2.500000e+01  1.847626e+01  3.116474e+01
+   endloop
+ endfacet
+ facet normal  1.774997e-01  2.958578e-01  9.385958e-01
+   outer loop
+     vertex  5.997501e+01  1.567120e+01  2.643331e+01
+     vertex  2.500000e+01  1.089188e+01  3.455401e+01
+     vertex  5.997501e+01  2.319666e+00  3.064189e+01
+   endloop
+ endfacet
+ facet normal  1.543581e-01  7.614045e-01  6.296323e-01
+   outer loop
+     vertex  5.997501e+01  2.577043e+01  1.673893e+01
+     vertex  2.500000e+01  3.038320e+01  1.973511e+01
+     vertex  2.500000e+01  2.508925e+01  2.613699e+01
+   endloop
+ endfacet
+ facet normal  1.543582e-01  8.848066e-01  4.396485e-01
+   outer loop
+     vertex  5.997501e+01  2.577043e+01  1.673893e+01
+     vertex  2.500000e+01  3.407976e+01  1.229566e+01
+     vertex  2.500000e+01  3.038320e+01  1.973511e+01
+   endloop
+ endfacet
+ facet normal  1.774998e-01  6.815031e-01  7.099629e-01
+   outer loop
+     vertex  5.997501e+01  2.577043e+01  1.673893e+01
+     vertex  2.500000e+01  2.508925e+01  2.613699e+01
+     vertex  5.997501e+01  1.567120e+01  2.643331e+01
+   endloop
+ endfacet
+ facet normal  1.774999e-01  9.257134e-01  3.339888e-01
+   outer loop
+     vertex  5.997501e+01  3.052142e+01  3.570648e+00
+     vertex  2.500000e+01  3.407976e+01  1.229566e+01
+     vertex  5.997501e+01  2.577043e+01  1.673893e+01
+   endloop
+ endfacet
+ facet normal  1.543581e-01  9.616905e-01  2.265502e-01
+   outer loop
+     vertex  5.997501e+01  3.052142e+01  3.570648e+00
+     vertex  2.500000e+01  3.598459e+01  4.209776e+00
+     vertex  2.500000e+01  3.407976e+01  1.229566e+01
+   endloop
+ endfacet
+ facet normal  1.543581e-01  9.880138e-01  1.541442e-03
+   outer loop
+     vertex  5.997501e+01  3.052142e+01  3.570648e+00
+     vertex  2.500000e+01  3.599755e+01 -4.097435e+00
+     vertex  2.500000e+01  3.598459e+01  4.209776e+00
+   endloop
+ endfacet
+ facet normal  1.774997e-01  9.778069e-01 -1.112992e-01
+   outer loop
+     vertex  5.997501e+01  2.893819e+01 -1.033866e+01
+     vertex  2.500000e+01  3.599755e+01 -4.097435e+00
+     vertex  5.997501e+01  3.052142e+01  3.570648e+00
+   endloop
+ endfacet
+ facet normal  1.543579e-01  9.623929e-01 -2.235478e-01
+   outer loop
+     vertex  5.997501e+01  2.893819e+01 -1.033866e+01
+     vertex  2.500000e+01  3.411796e+01 -1.218922e+01
+     vertex  2.500000e+01  3.599755e+01 -4.097435e+00
+   endloop
+ endfacet
+ facet normal  1.543580e-01  8.861749e-01 -4.368840e-01
+   outer loop
+     vertex  5.997501e+01  2.893819e+01 -1.033866e+01
+     vertex  2.500000e+01  3.044465e+01 -1.964017e+01
+     vertex  2.500000e+01  3.411796e+01 -1.218922e+01
+   endloop
+ endfacet
+ facet normal  1.774998e-01  8.269724e-01 -5.334889e-01
+   outer loop
+     vertex  5.997501e+01  2.134930e+01 -2.210235e+01
+     vertex  2.500000e+01  3.044465e+01 -1.964017e+01
+     vertex  5.997501e+01  2.893819e+01 -1.033866e+01
+   endloop
+ endfacet
+ facet normal  1.543582e-01  7.633666e-01 -6.272519e-01
+   outer loop
+     vertex  5.997501e+01  2.134930e+01 -2.210235e+01
+     vertex  2.500000e+01  2.517072e+01 -2.605855e+01
+     vertex  2.500000e+01  3.044465e+01 -1.964017e+01
+   endloop
+ endfacet
+ facet normal  1.543582e-01  6.004241e-01 -7.846429e-01
+   outer loop
+     vertex  5.997501e+01  2.134930e+01 -2.210235e+01
+     vertex  2.500000e+01  1.857345e+01 -3.110691e+01
+     vertex  2.500000e+01  2.517072e+01 -2.605855e+01
+   endloop
+ endfacet
+ facet normal  1.774998e-01  5.045132e-01 -8.449617e-01
+   outer loop
+     vertex  5.997501e+01  9.329714e+00 -2.927905e+01
+     vertex  2.500000e+01  1.857345e+01 -3.110691e+01
+     vertex  5.997501e+01  2.134930e+01 -2.210235e+01
+   endloop
+ endfacet
+ facet normal  1.653881e-01  1.515116e-01 -9.745209e-01
+   outer loop
+     vertex  5.997501e+01  9.329714e+00 -2.927905e+01
+     vertex  5.997501e+01 -2.677751e-15 -3.072957e+01
+     vertex  2.500000e+01  5.565912e+00 -3.579991e+01
+   endloop
+ endfacet
+ facet normal  1.543580e-01  4.059149e-01 -9.007812e-01
+   outer loop
+     vertex  5.997501e+01  9.329714e+00 -2.927905e+01
+     vertex  2.500000e+01  1.099968e+01 -3.451985e+01
+     vertex  2.500000e+01  1.857345e+01 -3.110691e+01
+   endloop
+ endfacet
+ facet normal  1.549072e-01  2.265309e-01 -9.616067e-01
+   outer loop
+     vertex  5.997501e+01  9.329714e+00 -2.927905e+01
+     vertex  2.500000e+01  5.565912e+00 -3.579991e+01
+     vertex  2.500000e+01  1.099968e+01 -3.451985e+01
+   endloop
+ endfacet
+ facet normal  9.810613e-01 -1.563352e-01 -1.143595e-01
+   outer loop
+     vertex  1.332498e+02 -1.114733e+00 -2.252250e+00
+     vertex  1.334950e+02 -5.953234e-16 -1.673008e+00
+     vertex  1.336900e+02 -8.498654e-22 -7.654907e-06
+   endloop
+ endfacet
+ facet normal  9.430496e-01 -3.553448e-02 -3.307488e-01
+   outer loop
+     vertex  1.332498e+02 -1.114733e+00 -2.252250e+00
+     vertex  1.329051e+02 -1.147442e-15 -3.354896e+00
+     vertex  1.334950e+02 -5.953234e-16 -1.673008e+00
+   endloop
+ endfacet
+ facet normal  8.831989e-01 -1.621754e-01 -4.400668e-01
+   outer loop
+     vertex  1.332498e+02 -1.114733e+00 -2.252250e+00
+     vertex  1.319141e+02 -2.236903e+00 -4.519526e+00
+     vertex  1.329051e+02 -1.147442e-15 -3.354896e+00
+   endloop
+ endfacet
+ facet normal  8.735425e-01 -3.096039e-01 -3.755914e-01
+   outer loop
+     vertex  1.332498e+02 -1.598446e+00 -1.939131e+00
+     vertex  1.319141e+02 -4.009574e+00 -3.058295e+00
+     vertex  1.319141e+02 -2.236903e+00 -4.519526e+00
+   endloop
+ endfacet
+ facet normal  8.830177e-01 -2.550429e-01 -3.939961e-01
+   outer loop
+     vertex  1.332498e+02 -1.598446e+00 -1.939131e+00
+     vertex  1.319141e+02 -2.236903e+00 -4.519526e+00
+     vertex  1.332498e+02 -1.114733e+00 -2.252250e+00
+   endloop
+ endfacet
+ facet normal  8.830177e-01 -3.380827e-01 -3.255455e-01
+   outer loop
+     vertex  1.332498e+02 -1.998121e+00 -1.524064e+00
+     vertex  1.319141e+02 -4.009574e+00 -3.058295e+00
+     vertex  1.332498e+02 -1.598446e+00 -1.939131e+00
+   endloop
+ endfacet
+ facet normal  8.830177e-01 -4.033480e-01 -2.399796e-01
+   outer loop
+     vertex  1.332498e+02 -2.292746e+00 -1.028870e+00
+     vertex  1.319141e+02 -4.009574e+00 -3.058295e+00
+     vertex  1.332498e+02 -1.998121e+00 -1.524064e+00
+   endloop
+ endfacet
+ facet normal  8.735425e-01 -4.440833e-01 -1.992823e-01
+   outer loop
+     vertex  1.332498e+02 -2.292746e+00 -1.028870e+00
+     vertex  1.319141e+02 -4.950122e+00 -9.623661e-01
+     vertex  1.319141e+02 -4.009574e+00 -3.058295e+00
+   endloop
+ endfacet
+ facet normal  8.830177e-01 -4.474075e-01 -1.417968e-01
+   outer loop
+     vertex  1.332498e+02 -2.466832e+00 -4.795830e-01
+     vertex  1.319141e+02 -4.950122e+00 -9.623661e-01
+     vertex  1.332498e+02 -2.292746e+00 -1.028870e+00
+   endloop
+ endfacet
+ facet normal  8.830177e-01 -4.679448e-01 -3.615916e-02
+   outer loop
+     vertex  1.332498e+02 -2.511225e+00  9.491712e-02
+     vertex  1.319141e+02 -4.950122e+00 -9.623661e-01
+     vertex  1.332498e+02 -2.466832e+00 -4.795830e-01
+   endloop
+ endfacet
+ facet normal  8.735425e-01 -4.864005e-01  1.838455e-02
+   outer loop
+     vertex  1.332498e+02 -2.511225e+00  9.491712e-02
+     vertex  1.319141e+02 -4.863352e+00  1.333287e+00
+     vertex  1.319141e+02 -4.950122e+00 -9.623661e-01
+   endloop
+ endfacet
+ facet normal  6.476909e-01 -2.532737e-01 -7.185742e-01
+   outer loop
+     vertex  1.283687e+02 -5.537832e+00 -6.718141e+00
+     vertex  1.280160e+02 -2.653589e-15 -8.987895e+00
+     vertex  1.305169e+02 -2.114976e-15 -6.733768e+00
+   endloop
+ endfacet
+ facet normal  5.184993e-01 -5.438863e-01 -6.598077e-01
+   outer loop
+     vertex  1.283687e+02 -5.537832e+00 -6.718141e+00
+     vertex  1.228903e+02 -9.822023e+00 -7.491731e+00
+     vertex  1.228903e+02 -5.479613e+00 -1.107122e+01
+   endloop
+ endfacet
+ facet normal  7.308317e-01 -4.341519e-01 -5.266851e-01
+   outer loop
+     vertex  1.283687e+02 -5.537832e+00 -6.718141e+00
+     vertex  1.319141e+02 -2.236903e+00 -4.519526e+00
+     vertex  1.319141e+02 -4.009574e+00 -3.058295e+00
+   endloop
+ endfacet
+ facet normal  5.969897e-01 -2.714089e-01 -7.549440e-01
+   outer loop
+     vertex  1.283687e+02 -5.537832e+00 -6.718141e+00
+     vertex  1.228903e+02 -5.479613e+00 -1.107122e+01
+     vertex  1.280160e+02 -2.653589e-15 -8.987895e+00
+   endloop
+ endfacet
+ facet normal  6.734317e-01 -2.631805e-01 -6.908153e-01
+   outer loop
+     vertex  1.283687e+02 -5.537832e+00 -6.718141e+00
+     vertex  1.305169e+02 -2.114976e-15 -6.733768e+00
+     vertex  1.319141e+02 -2.236903e+00 -4.519526e+00
+   endloop
+ endfacet
+ facet normal  6.958071e-01 -5.710696e-01 -4.355824e-01
+   outer loop
+     vertex  1.283687e+02 -7.943244e+00 -3.564529e+00
+     vertex  1.283687e+02 -5.537832e+00 -6.718141e+00
+     vertex  1.319141e+02 -4.009574e+00 -3.058295e+00
+   endloop
+ endfacet
+ facet normal  7.308317e-01 -6.227301e-01 -2.794500e-01
+   outer loop
+     vertex  1.283687e+02 -7.943244e+00 -3.564529e+00
+     vertex  1.319141e+02 -4.009574e+00 -3.058295e+00
+     vertex  1.319141e+02 -4.950122e+00 -9.623661e-01
+   endloop
+ endfacet
+ facet normal  5.775248e-01 -6.491050e-01 -4.951038e-01
+   outer loop
+     vertex  1.283687e+02 -7.943244e+00 -3.564529e+00
+     vertex  1.228903e+02 -9.822023e+00 -7.491731e+00
+     vertex  1.283687e+02 -5.537832e+00 -6.718141e+00
+   endloop
+ endfacet
+ facet normal  5.184993e-01 -7.801286e-01 -3.500826e-01
+   outer loop
+     vertex  1.283687e+02 -7.943244e+00 -3.564529e+00
+     vertex  1.228903e+02 -1.212603e+01 -2.357453e+00
+     vertex  1.228903e+02 -9.822023e+00 -7.491731e+00
+   endloop
+ endfacet
+ facet normal  5.775248e-01 -8.013692e-01 -1.557963e-01
+   outer loop
+     vertex  1.283687e+02 -8.700165e+00  3.288414e-01
+     vertex  1.228903e+02 -1.212603e+01 -2.357453e+00
+     vertex  1.283687e+02 -7.943244e+00 -3.564529e+00
+   endloop
+ endfacet
+ facet normal  5.184993e-01 -8.544679e-01  3.229645e-02
+   outer loop
+     vertex  1.283687e+02 -8.700165e+00  3.288414e-01
+     vertex  1.228903e+02 -1.191348e+01  3.266078e+00
+     vertex  1.228903e+02 -1.212603e+01 -2.357453e+00
+   endloop
+ endfacet
+ facet normal  6.958071e-01 -7.050286e-01 -1.370664e-01
+   outer loop
+     vertex  1.283687e+02 -8.700165e+00  3.288414e-01
+     vertex  1.283687e+02 -7.943244e+00 -3.564529e+00
+     vertex  1.319141e+02 -4.950122e+00 -9.623661e-01
+   endloop
+ endfacet
+ facet normal  7.308317e-01 -6.820707e-01  2.578032e-02
+   outer loop
+     vertex  1.283687e+02 -8.700165e+00  3.288414e-01
+     vertex  1.319141e+02 -4.950122e+00 -9.623661e-01
+     vertex  1.319141e+02 -4.863352e+00  1.333287e+00
+   endloop
+ endfacet
+ facet normal  6.958071e-01 -6.926704e-01  1.898955e-01
+   outer loop
+     vertex  1.283687e+02 -7.651507e+00  4.153967e+00
+     vertex  1.283687e+02 -8.700165e+00  3.288414e-01
+     vertex  1.319141e+02 -4.863352e+00  1.333287e+00
+   endloop
+ endfacet
+ facet normal  5.184993e-01 -7.514763e-01  4.079729e-01
+   outer loop
+     vertex  1.283687e+02 -7.651507e+00  4.153967e+00
+     vertex  1.228903e+02 -9.228474e+00  8.211787e+00
+     vertex  1.228903e+02 -1.191348e+01  3.266078e+00
+   endloop
+ endfacet
+ facet normal  5.775248e-01 -7.873223e-01  2.158443e-01
+   outer loop
+     vertex  1.283687e+02 -7.651507e+00  4.153967e+00
+     vertex  1.228903e+02 -1.191348e+01  3.266078e+00
+     vertex  1.283687e+02 -8.700165e+00  3.288414e-01
+   endloop
+ endfacet
+ facet normal  7.308317e-01 -5.998586e-01  3.256604e-01
+   outer loop
+     vertex  1.283687e+02 -7.651507e+00  4.153967e+00
+     vertex  1.319141e+02 -4.863352e+00  1.333287e+00
+     vertex  1.319141e+02 -3.767273e+00  3.352239e+00
+   endloop
+ endfacet
+ facet normal  2.967856e-01 -3.695527e-02 -9.542288e-01
+   outer loop
+     vertex  1.016981e+02 -4.766089e+00 -2.037411e+01
+     vertex  8.934905e+01 -3.796736e-15 -2.439952e+01
+     vertex  1.121276e+02 -3.860339e-15 -1.731491e+01
+   endloop
+ endfacet
+ facet normal  2.236745e-01 -2.220083e-01 -9.490427e-01
+   outer loop
+     vertex  1.016981e+02 -4.766089e+00 -2.037411e+01
+     vertex  8.934905e+01 -1.082322e+01 -2.186766e+01
+     vertex  8.934905e+01 -3.796736e-15 -2.439952e+01
+   endloop
+ endfacet
+ facet normal  3.631060e-01 -2.122329e-01 -9.072548e-01
+   outer loop
+     vertex  1.016981e+02 -4.766089e+00 -2.037411e+01
+     vertex  1.121276e+02 -3.860339e-15 -1.731491e+01
+     vertex  1.121276e+02 -7.680604e+00 -1.551819e+01
+   endloop
+ endfacet
+ facet normal  6.958071e-01 -5.365596e-01  4.774477e-01
+   outer loop
+     vertex  1.283687e+02 -5.014903e+00  7.117004e+00
+     vertex  1.283687e+02 -7.651507e+00  4.153967e+00
+     vertex  1.319141e+02 -3.767273e+00  3.352239e+00
+   endloop
+ endfacet
+ facet normal  5.184993e-01 -4.925279e-01  6.989813e-01
+   outer loop
+     vertex  1.283687e+02 -5.014903e+00  7.117004e+00
+     vertex  1.228903e+02 -4.628250e+00  1.145327e+01
+     vertex  1.228903e+02 -9.228474e+00  8.211787e+00
+   endloop
+ endfacet
+ facet normal  5.775248e-01 -6.098793e-01  5.426899e-01
+   outer loop
+     vertex  1.283687e+02 -5.014903e+00  7.117004e+00
+     vertex  1.228903e+02 -9.228474e+00  8.211787e+00
+     vertex  1.283687e+02 -7.651507e+00  4.153967e+00
+   endloop
+ endfacet
+ facet normal  7.308317e-01 -3.931556e-01  5.579550e-01
+   outer loop
+     vertex  1.283687e+02 -5.014903e+00  7.117004e+00
+     vertex  1.319141e+02 -3.767273e+00  3.352239e+00
+     vertex  1.319141e+02 -1.889357e+00  4.675487e+00
+   endloop
+ endfacet
+ facet normal  3.631060e-01 -5.926533e-01 -7.189687e-01
+   outer loop
+     vertex  1.016981e+02 -1.330915e+01 -1.614580e+01
+     vertex  1.121276e+02 -7.680604e+00 -1.551819e+01
+     vertex  1.121276e+02 -1.376723e+01 -1.050093e+01
+   endloop
+ endfacet
+ facet normal  2.236744e-01 -6.199508e-01 -7.520843e-01
+   outer loop
+     vertex  1.016981e+02 -1.330915e+01 -1.614580e+01
+     vertex  8.934905e+01 -1.940026e+01 -1.479752e+01
+     vertex  8.934905e+01 -1.082322e+01 -2.186766e+01
+   endloop
+ endfacet
+ facet normal  3.099187e-01 -4.217427e-01 -8.521054e-01
+   outer loop
+     vertex  1.016981e+02 -1.330915e+01 -1.614580e+01
+     vertex  8.934905e+01 -1.082322e+01 -2.186766e+01
+     vertex  1.016981e+02 -4.766089e+00 -2.037411e+01
+   endloop
+ endfacet
+ facet normal  2.814648e-01 -4.256500e-01 -8.599998e-01
+   outer loop
+     vertex  1.016981e+02 -1.330915e+01 -1.614580e+01
+     vertex  1.016981e+02 -4.766089e+00 -2.037411e+01
+     vertex  1.121276e+02 -7.680604e+00 -1.551819e+01
+   endloop
+ endfacet
+ facet normal  6.958071e-01 -2.690946e-01  6.659134e-01
+   outer loop
+     vertex  1.283687e+02 -1.337537e+00  8.603022e+00
+     vertex  1.283687e+02 -5.014903e+00  7.117004e+00
+     vertex  1.319141e+02 -1.889357e+00  4.675487e+00
+   endloop
+ endfacet
+ facet normal  5.775248e-01 -3.058658e-01  7.569090e-01
+   outer loop
+     vertex  1.283687e+02 -1.337537e+00  8.603022e+00
+     vertex  1.228903e+02 -4.628250e+00  1.145327e+01
+     vertex  1.283687e+02 -5.014903e+00  7.117004e+00
+   endloop
+ endfacet
+ facet normal  5.184993e-01 -1.313633e-01  8.449273e-01
+   outer loop
+     vertex  1.283687e+02 -1.337537e+00  8.603022e+00
+     vertex  1.228903e+02  9.324889e-01  1.231782e+01
+     vertex  1.228903e+02 -4.628250e+00  1.145327e+01
+   endloop
+ endfacet
+ facet normal  7.308317e-01 -1.048595e-01  6.744550e-01
+   outer loop
+     vertex  1.283687e+02 -1.337537e+00  8.603022e+00
+     vertex  1.319141e+02 -1.889357e+00  4.675487e+00
+     vertex  1.319141e+02  3.806632e-01  5.028414e+00
+   endloop
+ endfacet
+ facet normal  3.099187e-01 -7.559595e-01 -5.766070e-01
+   outer loop
+     vertex  1.016981e+02 -1.909010e+01 -8.566680e+00
+     vertex  8.934905e+01 -1.940026e+01 -1.479752e+01
+     vertex  1.016981e+02 -1.330915e+01 -1.614580e+01
+   endloop
+ endfacet
+ facet normal  2.814648e-01 -7.629632e-01 -5.819490e-01
+   outer loop
+     vertex  1.016981e+02 -1.909010e+01 -8.566680e+00
+     vertex  1.016981e+02 -1.330915e+01 -1.614580e+01
+     vertex  1.121276e+02 -1.376723e+01 -1.050093e+01
+   endloop
+ endfacet
+ facet normal  2.236745e-01 -8.892325e-01 -3.990429e-01
+   outer loop
+     vertex  1.016981e+02 -1.909010e+01 -8.566680e+00
+     vertex  8.934905e+01 -2.395109e+01 -4.656394e+00
+     vertex  8.934905e+01 -1.940026e+01 -1.479752e+01
+   endloop
+ endfacet
+ facet normal  3.631060e-01 -8.500781e-01 -3.814724e-01
+   outer loop
+     vertex  1.016981e+02 -1.909010e+01 -8.566680e+00
+     vertex  1.121276e+02 -1.376723e+01 -1.050093e+01
+     vertex  1.121276e+02 -1.699668e+01 -3.304369e+00
+   endloop
+ endfacet
+ facet normal  2.101190e-01 -7.176179e-02 -9.750386e-01
+   outer loop
+     vertex  7.545230e+01 -6.299836e+00 -2.693058e+01
+     vertex  5.997501e+01 -2.677751e-15 -3.072957e+01
+     vertex  8.934905e+01 -3.796736e-15 -2.439952e+01
+   endloop
+ endfacet
+ facet normal  1.447479e-01 -2.253805e-01 -9.634582e-01
+   outer loop
+     vertex  7.545230e+01 -6.299836e+00 -2.693058e+01
+     vertex  5.997501e+01 -1.363112e+01 -2.754086e+01
+     vertex  5.997501e+01 -2.677751e-15 -3.072957e+01
+   endloop
+ endfacet
+ facet normal  2.701702e-01 -2.193088e-01 -9.375029e-01
+   outer loop
+     vertex  7.545230e+01 -6.299836e+00 -2.693058e+01
+     vertex  8.934905e+01 -3.796736e-15 -2.439952e+01
+     vertex  8.934905e+01 -1.082322e+01 -2.186766e+01
+   endloop
+ endfacet
+ facet normal  7.308317e-01  2.051984e-01  6.509828e-01
+   outer loop
+     vertex  1.283687e+02  2.617412e+00  8.303623e+00
+     vertex  1.319141e+02  3.806632e-01  5.028414e+00
+     vertex  1.319141e+02  2.571684e+00  4.337775e+00
+   endloop
+ endfacet
+ facet normal  6.958071e-01  5.421657e-02  7.161795e-01
+   outer loop
+     vertex  1.283687e+02  2.617412e+00  8.303623e+00
+     vertex  1.283687e+02 -1.337537e+00  8.603022e+00
+     vertex  1.319141e+02  3.806632e-01  5.028414e+00
+   endloop
+ endfacet
+ facet normal  5.775248e-01  6.162515e-02  8.140439e-01
+   outer loop
+     vertex  1.283687e+02  2.617412e+00  8.303623e+00
+     vertex  1.228903e+02  9.324889e-01  1.231782e+01
+     vertex  1.283687e+02 -1.337537e+00  8.603022e+00
+   endloop
+ endfacet
+ facet normal  5.184993e-01  2.570635e-01  8.155224e-01
+   outer loop
+     vertex  1.283687e+02  2.617412e+00  8.303623e+00
+     vertex  1.228903e+02  6.299706e+00  1.062600e+01
+     vertex  1.228903e+02  9.324889e-01  1.231782e+01
+   endloop
+ endfacet
+ facet normal  3.631060e-01 -9.310830e-01  3.519228e-02
+   outer loop
+     vertex  1.016981e+02 -2.090922e+01  7.903088e-01
+     vertex  1.121276e+02 -1.699668e+01 -3.304369e+00
+     vertex  1.121276e+02 -1.669875e+01  4.577960e+00
+   endloop
+ endfacet
+ facet normal  2.236744e-01 -9.739684e-01  3.681322e-02
+   outer loop
+     vertex  1.016981e+02 -2.090922e+01  7.903088e-01
+     vertex  8.934905e+01 -2.353126e+01  6.451091e+00
+     vertex  8.934905e+01 -2.395109e+01 -4.656394e+00
+   endloop
+ endfacet
+ facet normal  2.814648e-01 -9.419358e-01 -1.831242e-01
+   outer loop
+     vertex  1.016981e+02 -2.090922e+01  7.903088e-01
+     vertex  1.016981e+02 -1.909010e+01 -8.566680e+00
+     vertex  1.121276e+02 -1.699668e+01 -3.304369e+00
+   endloop
+ endfacet
+ facet normal  3.099186e-01 -9.332892e-01 -1.814432e-01
+   outer loop
+     vertex  1.016981e+02 -2.090922e+01  7.903088e-01
+     vertex  8.934905e+01 -2.395109e+01 -4.656394e+00
+     vertex  1.016981e+02 -1.909010e+01 -8.566680e+00
+   endloop
+ endfacet
+ facet normal  8.880578e-01  4.324468e-01  1.560228e-01
+   outer loop
+     vertex  1.332498e+02  2.511225e+00 -9.491712e-02
+     vertex  1.319141e+02  5.008644e+00  5.859526e-01
+     vertex  1.319141e+02  4.228993e+00  2.746901e+00
+   endloop
+ endfacet
+ facet normal  8.741594e-01  4.825232e-01 -5.492339e-02
+   outer loop
+     vertex  1.332498e+02  2.511225e+00 -9.491712e-02
+     vertex  1.319141e+02  4.748831e+00 -1.696601e+00
+     vertex  1.319141e+02  5.008644e+00  5.859526e-01
+   endloop
+ endfacet
+ facet normal  2.701702e-01 -6.124126e-01 -7.429394e-01
+   outer loop
+     vertex  7.545230e+01 -1.759208e+01 -2.134158e+01
+     vertex  8.934905e+01 -1.082322e+01 -2.186766e+01
+     vertex  8.934905e+01 -1.940026e+01 -1.479752e+01
+   endloop
+ endfacet
+ facet normal  1.791856e-01 -4.364041e-01 -8.817278e-01
+   outer loop
+     vertex  7.545230e+01 -1.759208e+01 -2.134158e+01
+     vertex  7.545230e+01 -6.299836e+00 -2.693058e+01
+     vertex  8.934905e+01 -1.082322e+01 -2.186766e+01
+   endloop
+ endfacet
+ facet normal  2.383796e-01 -4.307958e-01 -8.703965e-01
+   outer loop
+     vertex  7.545230e+01 -1.759208e+01 -2.134158e+01
+     vertex  5.997501e+01 -1.363112e+01 -2.754086e+01
+     vertex  7.545230e+01 -6.299836e+00 -2.693058e+01
+   endloop
+ endfacet
+ facet normal  1.447479e-01 -6.293675e-01 -7.635081e-01
+   outer loop
+     vertex  7.545230e+01 -1.759208e+01 -2.134158e+01
+     vertex  5.997501e+01 -2.443334e+01 -1.863649e+01
+     vertex  5.997501e+01 -1.363112e+01 -2.754086e+01
+   endloop
+ endfacet
+ facet normal  6.958071e-01  3.662760e-01  6.178142e-01
+   outer loop
+     vertex  1.283687e+02  6.029161e+00  6.280941e+00
+     vertex  1.283687e+02  2.617412e+00  8.303623e+00
+     vertex  1.319141e+02  2.571684e+00  4.337775e+00
+   endloop
+ endfacet
+ facet normal  5.775248e-01  4.163268e-01  7.022372e-01
+   outer loop
+     vertex  1.283687e+02  6.029161e+00  6.280941e+00
+     vertex  1.228903e+02  6.299706e+00  1.062600e+01
+     vertex  1.283687e+02  2.617412e+00  8.303623e+00
+   endloop
+ endfacet
+ facet normal  7.308317e-01  4.726708e-01  4.924097e-01
+   outer loop
+     vertex  1.283687e+02  6.029161e+00  6.280941e+00
+     vertex  1.319141e+02  2.571684e+00  4.337775e+00
+     vertex  1.319141e+02  4.228993e+00  2.746901e+00
+   endloop
+ endfacet
+ facet normal  5.184993e-01  5.921410e-01  6.168691e-01
+   outer loop
+     vertex  1.283687e+02  6.029161e+00  6.280941e+00
+     vertex  1.228903e+02  1.035952e+01  6.728927e+00
+     vertex  1.228903e+02  6.299706e+00  1.062600e+01
+   endloop
+ endfacet
+ facet normal  8.784100e-01  4.723486e-01 -7.268259e-02
+   outer loop
+     vertex  1.332498e+02  2.423591e+00 -6.644272e-01
+     vertex  1.319141e+02  4.748831e+00 -1.696601e+00
+     vertex  1.332498e+02  2.511225e+00 -9.491712e-02
+   endloop
+ endfacet
+ facet normal  3.099187e-01 -9.169299e-01  2.513762e-01
+   outer loop
+     vertex  1.016981e+02 -1.838897e+01  9.983283e+00
+     vertex  8.934905e+01 -2.353126e+01  6.451091e+00
+     vertex  1.016981e+02 -2.090922e+01  7.903088e-01
+   endloop
+ endfacet
+ facet normal  2.236744e-01 -8.565730e-01  4.650294e-01
+   outer loop
+     vertex  1.016981e+02 -1.838897e+01  9.983283e+00
+     vertex  8.934905e+01 -1.822790e+01  1.621976e+01
+     vertex  8.934905e+01 -2.353126e+01  6.451091e+00
+   endloop
+ endfacet
+ facet normal  2.814648e-01 -9.254249e-01  2.537051e-01
+   outer loop
+     vertex  1.016981e+02 -1.838897e+01  9.983283e+00
+     vertex  1.016981e+02 -2.090922e+01  7.903088e-01
+     vertex  1.121276e+02 -1.669875e+01  4.577960e+00
+   endloop
+ endfacet
+ facet normal  3.631060e-01 -8.188567e-01  4.445534e-01
+   outer loop
+     vertex  1.016981e+02 -1.838897e+01  9.983283e+00
+     vertex  1.121276e+02 -1.669875e+01  4.577960e+00
+     vertex  1.121276e+02 -1.293527e+01  1.151021e+01
+   endloop
+ endfacet
+ facet normal  8.852585e-01  4.314932e-01 -1.735829e-01
+   outer loop
+     vertex  1.332498e+02  2.208539e+00 -1.199005e+00
+     vertex  1.319141e+02  4.748831e+00 -1.696601e+00
+     vertex  1.332498e+02  2.423591e+00 -6.644272e-01
+   endloop
+ endfacet
+ facet normal  9.848089e-01  1.610950e-01 -6.480598e-02
+   outer loop
+     vertex  1.332498e+02  2.208539e+00 -1.199005e+00
+     vertex  1.332498e+02  2.423591e+00 -6.644272e-01
+     vertex  1.336900e+02 -8.498654e-22 -7.654907e-06
+   endloop
+ endfacet
+ facet normal  8.741594e-01  4.080902e-01 -2.632634e-01
+   outer loop
+     vertex  1.332498e+02  2.208539e+00 -1.199005e+00
+     vertex  1.319141e+02  3.503476e+00 -3.627052e+00
+     vertex  1.319141e+02  4.748831e+00 -1.696601e+00
+   endloop
+ endfacet
+ facet normal  1.791856e-01 -7.822396e-01 -5.966521e-01
+   outer loop
+     vertex  7.545230e+01 -2.523338e+01 -1.132347e+01
+     vertex  7.545230e+01 -1.759208e+01 -2.134158e+01
+     vertex  8.934905e+01 -1.940026e+01 -1.479752e+01
+   endloop
+ endfacet
+ facet normal  1.447479e-01 -9.027395e-01 -4.051042e-01
+   outer loop
+     vertex  7.545230e+01 -2.523338e+01 -1.132347e+01
+     vertex  5.997501e+01 -3.016480e+01 -5.864418e+00
+     vertex  5.997501e+01 -2.443334e+01 -1.863649e+01
+   endloop
+ endfacet
+ facet normal  2.383796e-01 -7.721869e-01 -5.889843e-01
+   outer loop
+     vertex  7.545230e+01 -2.523338e+01 -1.132347e+01
+     vertex  5.997501e+01 -2.443334e+01 -1.863649e+01
+     vertex  7.545230e+01 -1.759208e+01 -2.134158e+01
+   endloop
+ endfacet
+ facet normal  2.701702e-01 -8.784200e-01 -3.941908e-01
+   outer loop
+     vertex  7.545230e+01 -2.523338e+01 -1.132347e+01
+     vertex  8.934905e+01 -1.940026e+01 -1.479752e+01
+     vertex  8.934905e+01 -2.395109e+01 -4.656394e+00
+   endloop
+ endfacet
+ facet normal  5.184993e-01  8.043293e-01  2.901945e-01
+   outer loop
+     vertex  1.283687e+02  8.189655e+00  2.954751e+00
+     vertex  1.228903e+02  1.226939e+01  1.435374e+00
+     vertex  1.228903e+02  1.035952e+01  6.728927e+00
+   endloop
+ endfacet
+ facet normal  5.775248e-01  6.846267e-01  4.446926e-01
+   outer loop
+     vertex  1.283687e+02  8.189655e+00  2.954751e+00
+     vertex  1.228903e+02  1.035952e+01  6.728927e+00
+     vertex  1.283687e+02  6.029161e+00  6.280941e+00
+   endloop
+ endfacet
+ facet normal  6.958071e-01  6.023208e-01  3.912316e-01
+   outer loop
+     vertex  1.283687e+02  8.189655e+00  2.954751e+00
+     vertex  1.283687e+02  6.029161e+00  6.280941e+00
+     vertex  1.319141e+02  4.228993e+00  2.746901e+00
+   endloop
+ endfacet
+ facet normal  7.308317e-01  6.420480e-01  2.316450e-01
+   outer loop
+     vertex  1.283687e+02  8.189655e+00  2.954751e+00
+     vertex  1.319141e+02  4.228993e+00  2.746901e+00
+     vertex  1.319141e+02  5.008644e+00  5.859526e-01
+   endloop
+ endfacet
+ facet normal  9.848089e-01  1.420989e-01 -9.979660e-02
+   outer loop
+     vertex  1.332498e+02  1.877374e+00 -1.670547e+00
+     vertex  1.332498e+02  2.208539e+00 -1.199005e+00
+     vertex  1.336900e+02 -8.498654e-22 -7.654907e-06
+   endloop
+ endfacet
+ facet normal  8.784100e-01  3.910936e-01 -2.746665e-01
+   outer loop
+     vertex  1.332498e+02  1.877374e+00 -1.670547e+00
+     vertex  1.319141e+02  3.503476e+00 -3.627052e+00
+     vertex  1.332498e+02  2.208539e+00 -1.199005e+00
+   endloop
+ endfacet
+ facet normal  2.236744e-01 -5.614097e-01  7.967364e-01
+   outer loop
+     vertex  1.016981e+02 -1.205238e+01  1.710439e+01
+     vertex  8.934905e+01 -9.141626e+00  2.262228e+01
+     vertex  8.934905e+01 -1.822790e+01  1.621976e+01
+   endloop
+ endfacet
+ facet normal  2.814648e-01 -7.168571e-01  6.378821e-01
+   outer loop
+     vertex  1.016981e+02 -1.205238e+01  1.710439e+01
+     vertex  1.016981e+02 -1.838897e+01  9.983283e+00
+     vertex  1.121276e+02 -1.293527e+01  1.151021e+01
+   endloop
+ endfacet
+ facet normal  3.099187e-01 -7.102766e-01  6.320266e-01
+   outer loop
+     vertex  1.016981e+02 -1.205238e+01  1.710439e+01
+     vertex  8.934905e+01 -1.822790e+01  1.621976e+01
+     vertex  1.016981e+02 -1.838897e+01  9.983283e+00
+   endloop
+ endfacet
+ facet normal  3.631060e-01 -5.366899e-01  7.616548e-01
+   outer loop
+     vertex  1.016981e+02 -1.205238e+01  1.710439e+01
+     vertex  1.121276e+02 -1.293527e+01  1.151021e+01
+     vertex  1.121276e+02 -6.487275e+00  1.605370e+01
+   endloop
+ endfacet
+ facet normal  8.741594e-01  2.489647e-01 -4.169675e-01
+   outer loop
+     vertex  1.332498e+02  1.447507e+00 -2.054260e+00
+     vertex  1.319141e+02  1.531030e+00 -4.804768e+00
+     vertex  1.319141e+02  3.503476e+00 -3.627052e+00
+   endloop
+ endfacet
+ facet normal  9.848089e-01  1.156320e-01 -1.295405e-01
+   outer loop
+     vertex  1.332498e+02  1.447507e+00 -2.054260e+00
+     vertex  1.332498e+02  1.877374e+00 -1.670547e+00
+     vertex  1.336900e+02 -8.498654e-22 -7.654907e-06
+   endloop
+ endfacet
+ facet normal  8.852585e-01  3.097200e-01 -3.469739e-01
+   outer loop
+     vertex  1.332498e+02  1.447507e+00 -2.054260e+00
+     vertex  1.319141e+02  3.503476e+00 -3.627052e+00
+     vertex  1.332498e+02  1.877374e+00 -1.670547e+00
+   endloop
+ endfacet
+ facet normal  1.447479e-01 -9.887625e-01  3.737240e-02
+   outer loop
+     vertex  7.545230e+01 -2.763789e+01  1.044633e+00
+     vertex  5.997501e+01 -2.963605e+01  8.124719e+00
+     vertex  5.997501e+01 -3.016480e+01 -5.864418e+00
+   endloop
+ endfacet
+ facet normal  2.701702e-01 -9.621256e-01  3.636560e-02
+   outer loop
+     vertex  7.545230e+01 -2.763789e+01  1.044633e+00
+     vertex  8.934905e+01 -2.395109e+01 -4.656394e+00
+     vertex  8.934905e+01 -2.353126e+01  6.451091e+00
+   endloop
+ endfacet
+ facet normal  1.791856e-01 -9.657340e-01 -1.877508e-01
+   outer loop
+     vertex  7.545230e+01 -2.763789e+01  1.044633e+00
+     vertex  7.545230e+01 -2.523338e+01 -1.132347e+01
+     vertex  8.934905e+01 -2.395109e+01 -4.656394e+00
+   endloop
+ endfacet
+ facet normal  2.383796e-01 -9.533231e-01 -1.853380e-01
+   outer loop
+     vertex  7.545230e+01 -2.763789e+01  1.044633e+00
+     vertex  5.997501e+01 -3.016480e+01 -5.864418e+00
+     vertex  7.545230e+01 -2.523338e+01 -1.132347e+01
+   endloop
+ endfacet
+ facet normal  5.775248e-01  8.108433e-01  9.485917e-02
+   outer loop
+     vertex  1.283687e+02  8.650518e+00 -9.846485e-01
+     vertex  1.228903e+02  1.226939e+01  1.435374e+00
+     vertex  1.283687e+02  8.189655e+00  2.954751e+00
+   endloop
+ endfacet
+ facet normal  6.958071e-01  7.133637e-01  8.345519e-02
+   outer loop
+     vertex  1.283687e+02  8.650518e+00 -9.846485e-01
+     vertex  1.283687e+02  8.189655e+00  2.954751e+00
+     vertex  1.319141e+02  5.008644e+00  5.859526e-01
+   endloop
+ endfacet
+ facet normal  5.184993e-01  8.495920e-01 -9.670513e-02
+   outer loop
+     vertex  1.283687e+02  8.650518e+00 -9.846485e-01
+     vertex  1.228903e+02  1.163294e+01 -4.156066e+00
+     vertex  1.228903e+02  1.226939e+01  1.435374e+00
+   endloop
+ endfacet
+ facet normal  7.308317e-01  6.781785e-01 -7.719393e-02
+   outer loop
+     vertex  1.283687e+02  8.650518e+00 -9.846485e-01
+     vertex  1.319141e+02  5.008644e+00  5.859526e-01
+     vertex  1.319141e+02  4.748831e+00 -1.696601e+00
+   endloop
+ endfacet
+ facet normal  9.779304e-01  1.750923e-01 -1.139946e-01
+   outer loop
+     vertex  1.332498e+02  9.415381e-01 -2.329971e+00
+     vertex  1.336900e+02 -8.498654e-22 -7.654907e-06
+     vertex  1.334950e+02 -5.953234e-16 -1.673008e+00
+   endloop
+ endfacet
+ facet normal  9.435425e-01  1.477638e-02 -3.309216e-01
+   outer loop
+     vertex  1.332498e+02  9.415381e-01 -2.329971e+00
+     vertex  1.334950e+02 -5.953234e-16 -1.673008e+00
+     vertex  1.329051e+02 -1.147442e-15 -3.354896e+00
+   endloop
+ endfacet
+ facet normal  8.843037e-01  1.554886e-01 -4.402615e-01
+   outer loop
+     vertex  1.332498e+02  9.415381e-01 -2.329971e+00
+     vertex  1.329051e+02 -1.147442e-15 -3.354896e+00
+     vertex  1.319141e+02  1.531030e+00 -4.804768e+00
+   endloop
+ endfacet
+ facet normal  9.848089e-01  8.308571e-02 -1.524739e-01
+   outer loop
+     vertex  1.332498e+02  9.415381e-01 -2.329971e+00
+     vertex  1.332498e+02  1.447507e+00 -2.054260e+00
+     vertex  1.336900e+02 -8.498654e-22 -7.654907e-06
+   endloop
+ endfacet
+ facet normal  8.784100e-01  2.286736e-01 -4.196479e-01
+   outer loop
+     vertex  1.332498e+02  9.415381e-01 -2.329971e+00
+     vertex  1.319141e+02  1.531030e+00 -4.804768e+00
+     vertex  1.332498e+02  1.447507e+00 -2.054260e+00
+   endloop
+ endfacet
+ facet normal  3.631060e-01 -1.431419e-01  9.206870e-01
+   outer loop
+     vertex  1.016981e+02 -3.214520e+00  2.067576e+01
+     vertex  1.121276e+02 -6.487275e+00  1.605370e+01
+     vertex  1.121276e+02  1.307041e+00  1.726551e+01
+   endloop
+ endfacet
+ facet normal  2.236745e-01 -1.497350e-01  9.630935e-01
+   outer loop
+     vertex  1.016981e+02 -3.214520e+00  2.067576e+01
+     vertex  8.934905e+01  1.841833e+00  2.432991e+01
+     vertex  8.934905e+01 -9.141626e+00  2.262228e+01
+   endloop
+ endfacet
+ facet normal  2.814648e-01 -3.595171e-01  8.896769e-01
+   outer loop
+     vertex  1.016981e+02 -3.214520e+00  2.067576e+01
+     vertex  1.016981e+02 -1.205238e+01  1.710439e+01
+     vertex  1.121276e+02 -6.487275e+00  1.605370e+01
+   endloop
+ endfacet
+ facet normal  3.099187e-01 -3.562169e-01  8.815100e-01
+   outer loop
+     vertex  1.016981e+02 -3.214520e+00  2.067576e+01
+     vertex  8.934905e+01 -9.141626e+00  2.262228e+01
+     vertex  1.016981e+02 -1.205238e+01  1.710439e+01
+   endloop
+ endfacet
+ facet normal  1.447479e-01 -8.695839e-01  4.720930e-01
+   outer loop
+     vertex  7.545230e+01 -2.430661e+01  1.319594e+01
+     vertex  5.997501e+01 -2.295682e+01  2.042770e+01
+     vertex  5.997501e+01 -2.963605e+01  8.124719e+00
+   endloop
+ endfacet
+ facet normal  1.791856e-01 -9.488059e-01  2.601150e-01
+   outer loop
+     vertex  7.545230e+01 -2.430661e+01  1.319594e+01
+     vertex  7.545230e+01 -2.763789e+01  1.044633e+00
+     vertex  8.934905e+01 -2.353126e+01  6.451091e+00
+   endloop
+ endfacet
+ facet normal  2.383796e-01 -9.366126e-01  2.567722e-01
+   outer loop
+     vertex  7.545230e+01 -2.430661e+01  1.319594e+01
+     vertex  5.997501e+01 -2.963605e+01  8.124719e+00
+     vertex  7.545230e+01 -2.763789e+01  1.044633e+00
+   endloop
+ endfacet
+ facet normal  2.701702e-01 -8.461576e-01  4.593750e-01
+   outer loop
+     vertex  7.545230e+01 -2.430661e+01  1.319594e+01
+     vertex  8.934905e+01 -2.353126e+01  6.451091e+00
+     vertex  8.934905e+01 -1.822790e+01  1.621976e+01
+   endloop
+ endfacet
+ facet normal  6.321808e-01  3.972148e-01 -6.652577e-01
+   outer loop
+     vertex  1.283687e+02  7.316107e+00 -4.719700e+00
+     vertex  1.319141e+02  3.503476e+00 -3.627052e+00
+     vertex  1.319141e+02  1.531030e+00 -4.804768e+00
+   endloop
+ endfacet
+ facet normal  5.775248e-01  7.687826e-01 -2.746607e-01
+   outer loop
+     vertex  1.283687e+02  7.316107e+00 -4.719700e+00
+     vertex  1.228903e+02  1.163294e+01 -4.156066e+00
+     vertex  1.283687e+02  8.650518e+00 -9.846485e-01
+   endloop
+ endfacet
+ facet normal  5.184993e-01  7.185357e-01 -4.635352e-01
+   outer loop
+     vertex  1.283687e+02  7.316107e+00 -4.719700e+00
+     vertex  1.228903e+02  8.582265e+00 -8.884982e+00
+     vertex  1.228903e+02  1.163294e+01 -4.156066e+00
+   endloop
+ endfacet
+ facet normal  6.958071e-01  6.763595e-01 -2.416409e-01
+   outer loop
+     vertex  1.283687e+02  7.316107e+00 -4.719700e+00
+     vertex  1.283687e+02  8.650518e+00 -9.846485e-01
+     vertex  1.319141e+02  4.748831e+00 -1.696601e+00
+   endloop
+ endfacet
+ facet normal  7.308317e-01  5.735641e-01 -3.700125e-01
+   outer loop
+     vertex  1.283687e+02  7.316107e+00 -4.719700e+00
+     vertex  1.319141e+02  4.748831e+00 -1.696601e+00
+     vertex  1.319141e+02  3.503476e+00 -3.627052e+00
+   endloop
+ endfacet
+ facet normal  2.814648e-01  7.243469e-02  9.568337e-01
+   outer loop
+     vertex  1.016981e+02  6.290461e+00  1.995621e+01
+     vertex  1.016981e+02 -3.214520e+00  2.067576e+01
+     vertex  1.121276e+02  1.307041e+00  1.726551e+01
+   endloop
+ endfacet
+ facet normal  3.631060e-01  2.801128e-01  8.886455e-01
+   outer loop
+     vertex  1.016981e+02  6.290461e+00  1.995621e+01
+     vertex  1.121276e+02  1.307041e+00  1.726551e+01
+     vertex  1.121276e+02  8.830104e+00  1.489414e+01
+   endloop
+ endfacet
+ facet normal  2.236744e-01  2.930148e-01  9.295763e-01
+   outer loop
+     vertex  1.016981e+02  6.290461e+00  1.995621e+01
+     vertex  8.934905e+01  1.244305e+01  2.098826e+01
+     vertex  8.934905e+01  1.841833e+00  2.432991e+01
+   endloop
+ endfacet
+ facet normal  3.099186e-01  7.176977e-02  9.480504e-01
+   outer loop
+     vertex  1.016981e+02  6.290461e+00  1.995621e+01
+     vertex  8.934905e+01  1.841833e+00  2.432991e+01
+     vertex  1.016981e+02 -3.214520e+00  2.067576e+01
+   endloop
+ endfacet
+ facet normal  2.701702e-01 -5.545833e-01  7.870485e-01
+   outer loop
+     vertex  7.545230e+01 -1.593089e+01  2.260865e+01
+     vertex  8.934905e+01 -1.822790e+01  1.621976e+01
+     vertex  8.934905e+01 -9.141626e+00  2.262228e+01
+   endloop
+ endfacet
+ facet normal  2.383797e-01 -7.255233e-01  6.455936e-01
+   outer loop
+     vertex  7.545230e+01 -1.593089e+01  2.260865e+01
+     vertex  5.997501e+01 -2.295682e+01  2.042770e+01
+     vertex  7.545230e+01 -2.430661e+01  1.319594e+01
+   endloop
+ endfacet
+ facet normal  1.447479e-01 -5.699372e-01  8.088384e-01
+   outer loop
+     vertex  7.545230e+01 -1.593089e+01  2.260865e+01
+     vertex  5.997501e+01 -1.151327e+01  2.849125e+01
+     vertex  5.997501e+01 -2.295682e+01  2.042770e+01
+   endloop
+ endfacet
+ facet normal  1.791856e-01 -7.349686e-01  6.539983e-01
+   outer loop
+     vertex  7.545230e+01 -1.593089e+01  2.260865e+01
+     vertex  7.545230e+01 -2.430661e+01  1.319594e+01
+     vertex  8.934905e+01 -1.822790e+01  1.621976e+01
+   endloop
+ endfacet
+ facet normal  2.814648e-01  4.893539e-01  8.254153e-01
+   outer loop
+     vertex  1.016981e+02  1.448996e+01  1.509507e+01
+     vertex  1.016981e+02  6.290461e+00  1.995621e+01
+     vertex  1.121276e+02  8.830104e+00  1.489414e+01
+   endloop
+ endfacet
+ facet normal  3.631060e-01  6.452348e-01  6.721801e-01
+   outer loop
+     vertex  1.016981e+02  1.448996e+01  1.509507e+01
+     vertex  1.121276e+02  8.830104e+00  1.489414e+01
+     vertex  1.121276e+02  1.452062e+01  9.431729e+00
+   endloop
+ endfacet
+ facet normal  2.236744e-01  6.749542e-01  7.031405e-01
+   outer loop
+     vertex  1.016981e+02  1.448996e+01  1.509507e+01
+     vertex  8.934905e+01  2.046192e+01  1.329084e+01
+     vertex  8.934905e+01  1.244305e+01  2.098826e+01
+   endloop
+ endfacet
+ facet normal  3.099187e-01  4.848618e-01  8.178383e-01
+   outer loop
+     vertex  1.016981e+02  1.448996e+01  1.509507e+01
+     vertex  8.934905e+01  1.244305e+01  2.098826e+01
+     vertex  1.016981e+02  6.290461e+00  1.995621e+01
+   endloop
+ endfacet
+ facet normal  2.701702e-01 -1.479143e-01  9.513829e-01
+   outer loop
+     vertex  7.545230e+01 -4.248966e+00  2.732930e+01
+     vertex  8.934905e+01 -9.141626e+00  2.262228e+01
+     vertex  8.934905e+01  1.841833e+00  2.432991e+01
+   endloop
+ endfacet
+ facet normal  1.447479e-01 -1.520094e-01  9.777224e-01
+   outer loop
+     vertex  7.545230e+01 -4.248966e+00  2.732930e+01
+     vertex  5.997501e+01  2.319666e+00  3.064189e+01
+     vertex  5.997501e+01 -1.151327e+01  2.849125e+01
+   endloop
+ endfacet
+ facet normal  1.791856e-01 -3.686004e-01  9.121547e-01
+   outer loop
+     vertex  7.545230e+01 -4.248966e+00  2.732930e+01
+     vertex  7.545230e+01 -1.593089e+01  2.260865e+01
+     vertex  8.934905e+01 -9.141626e+00  2.262228e+01
+   endloop
+ endfacet
+ facet normal  2.383796e-01 -3.638634e-01  9.004324e-01
+   outer loop
+     vertex  7.545230e+01 -4.248966e+00  2.732930e+01
+     vertex  5.997501e+01 -1.151327e+01  2.849125e+01
+     vertex  7.545230e+01 -1.593089e+01  2.260865e+01
+   endloop
+ endfacet
+ facet normal  6.694522e-01  2.639418e-01 -6.943835e-01
+   outer loop
+     vertex  1.256595e+02  3.999206e+00 -9.896608e+00
+     vertex  1.319141e+02  1.531030e+00 -4.804768e+00
+     vertex  1.305169e+02 -2.114976e-15 -6.733768e+00
+   endloop
+ endfacet
+ facet normal  6.530875e-01  2.201987e-01 -7.245614e-01
+   outer loop
+     vertex  1.256595e+02  3.999206e+00 -9.896608e+00
+     vertex  1.305169e+02 -2.114976e-15 -6.733768e+00
+     vertex  1.280160e+02 -2.653589e-15 -8.987895e+00
+   endloop
+ endfacet
+ facet normal  5.439938e-01  1.322752e-01 -8.285976e-01
+   outer loop
+     vertex  1.256595e+02  3.999206e+00 -9.896608e+00
+     vertex  1.280160e+02 -2.653589e-15 -8.987895e+00
+     vertex  1.228903e+02 -3.293760e-15 -1.235306e+01
+   endloop
+ endfacet
+ facet normal  6.670376e-01  4.178644e-01 -6.168064e-01
+   outer loop
+     vertex  1.256595e+02  3.999206e+00 -9.896608e+00
+     vertex  1.283687e+02  7.316107e+00 -4.719700e+00
+     vertex  1.319141e+02  1.531030e+00 -4.804768e+00
+   endloop
+ endfacet
+ facet normal  5.477338e-01  1.285326e-01 -8.267206e-01
+   outer loop
+     vertex  1.256595e+02  3.999206e+00 -9.896608e+00
+     vertex  1.228903e+02 -3.293760e-15 -1.235306e+01
+     vertex  1.228903e+02  3.750477e+00 -1.176997e+01
+   endloop
+ endfacet
+ facet normal  4.715917e-01  4.520668e-01 -7.571241e-01
+   outer loop
+     vertex  1.256595e+02  3.999206e+00 -9.896608e+00
+     vertex  1.228903e+02  3.750477e+00 -1.176997e+01
+     vertex  1.228903e+02  8.582265e+00 -8.884982e+00
+   endloop
+ endfacet
+ facet normal  5.947293e-01  4.985558e-01 -6.306657e-01
+   outer loop
+     vertex  1.256595e+02  3.999206e+00 -9.896608e+00
+     vertex  1.228903e+02  8.582265e+00 -8.884982e+00
+     vertex  1.283687e+02  7.316107e+00 -4.719700e+00
+   endloop
+ endfacet
+ facet normal  3.631060e-01  8.764487e-01  3.162146e-01
+   outer loop
+     vertex  1.016981e+02  1.968230e+01  7.101193e+00
+     vertex  1.121276e+02  1.452062e+01  9.431729e+00
+     vertex  1.121276e+02  1.719762e+01  2.011920e+00
+   endloop
+ endfacet
+ facet normal  2.236744e-01  9.168177e-01  3.307793e-01
+   outer loop
+     vertex  1.016981e+02  1.968230e+01  7.101193e+00
+     vertex  8.934905e+01  2.423425e+01  2.835123e+00
+     vertex  8.934905e+01  2.046192e+01  1.329084e+01
+   endloop
+ endfacet
+ facet normal  2.814648e-01  8.047157e-01  5.226952e-01
+   outer loop
+     vertex  1.016981e+02  1.968230e+01  7.101193e+00
+     vertex  1.016981e+02  1.448996e+01  1.509507e+01
+     vertex  1.121276e+02  1.452062e+01  9.431729e+00
+   endloop
+ endfacet
+ facet normal  3.099187e-01  7.973287e-01  5.178971e-01
+   outer loop
+     vertex  1.016981e+02  1.968230e+01  7.101193e+00
+     vertex  8.934905e+01  2.046192e+01  1.329084e+01
+     vertex  1.016981e+02  1.448996e+01  1.509507e+01
+   endloop
+ endfacet
+ facet normal  2.383796e-01  7.331037e-02  9.684011e-01
+   outer loop
+     vertex  7.545230e+01  8.314756e+00  2.637819e+01
+     vertex  5.997501e+01  2.319666e+00  3.064189e+01
+     vertex  7.545230e+01 -4.248966e+00  2.732930e+01
+   endloop
+ endfacet
+ facet normal  2.701702e-01  2.894519e-01  9.182732e-01
+   outer loop
+     vertex  7.545230e+01  8.314756e+00  2.637819e+01
+     vertex  8.934905e+01  1.841833e+00  2.432991e+01
+     vertex  8.934905e+01  1.244305e+01  2.098826e+01
+   endloop
+ endfacet
+ facet normal  1.447479e-01  2.974655e-01  9.436961e-01
+   outer loop
+     vertex  7.545230e+01  8.314756e+00  2.637819e+01
+     vertex  5.997501e+01  1.567120e+01  2.643331e+01
+     vertex  5.997501e+01  2.319666e+00  3.064189e+01
+   endloop
+ endfacet
+ facet normal  1.791856e-01  7.426476e-02  9.810083e-01
+   outer loop
+     vertex  7.545230e+01  8.314756e+00  2.637819e+01
+     vertex  7.545230e+01 -4.248966e+00  2.732930e+01
+     vertex  8.934905e+01  1.841833e+00  2.432991e+01
+   endloop
+ endfacet
+ facet normal  3.099187e-01  9.443229e-01  1.104747e-01
+   outer loop
+     vertex  1.016981e+02  2.078990e+01 -2.366419e+00
+     vertex  8.934905e+01  2.423425e+01  2.835123e+00
+     vertex  1.016981e+02  1.968230e+01  7.101193e+00
+   endloop
+ endfacet
+ facet normal  2.236744e-01  9.684106e-01 -1.102297e-01
+   outer loop
+     vertex  1.016981e+02  2.078990e+01 -2.366419e+00
+     vertex  8.934905e+01  2.297715e+01 -8.208978e+00
+     vertex  8.934905e+01  2.423425e+01  2.835123e+00
+   endloop
+ endfacet
+ facet normal  3.631060e-01  9.257699e-01 -1.053761e-01
+   outer loop
+     vertex  1.016981e+02  2.078990e+01 -2.366419e+00
+     vertex  1.121276e+02  1.719762e+01  2.011920e+00
+     vertex  1.121276e+02  1.630553e+01 -5.825429e+00
+   endloop
+ endfacet
+ facet normal  2.814648e-01  9.530717e-01  1.114982e-01
+   outer loop
+     vertex  1.016981e+02  2.078990e+01 -2.366419e+00
+     vertex  1.016981e+02  1.968230e+01  7.101193e+00
+     vertex  1.121276e+02  1.719762e+01  2.011920e+00
+   endloop
+ endfacet
+ facet normal  2.383796e-01  4.952698e-01  8.353939e-01
+   outer loop
+     vertex  7.545230e+01  1.915289e+01  1.995272e+01
+     vertex  5.997501e+01  1.567120e+01  2.643331e+01
+     vertex  7.545230e+01  8.314756e+00  2.637819e+01
+   endloop
+ endfacet
+ facet normal  2.701702e-01  6.667471e-01  6.945908e-01
+   outer loop
+     vertex  7.545230e+01  1.915289e+01  1.995272e+01
+     vertex  8.934905e+01  1.244305e+01  2.098826e+01
+     vertex  8.934905e+01  2.046192e+01  1.329084e+01
+   endloop
+ endfacet
+ facet normal  1.791856e-01  5.017175e-01  8.462695e-01
+   outer loop
+     vertex  7.545230e+01  1.915289e+01  1.995272e+01
+     vertex  7.545230e+01  8.314756e+00  2.637819e+01
+     vertex  8.934905e+01  1.244305e+01  2.098826e+01
+   endloop
+ endfacet
+ facet normal  1.447479e-01  6.852064e-01  7.138209e-01
+   outer loop
+     vertex  7.545230e+01  1.915289e+01  1.995272e+01
+     vertex  5.997501e+01  2.577043e+01  1.673893e+01
+     vertex  5.997501e+01  1.567120e+01  2.643331e+01
+   endloop
+ endfacet
+ facet normal  2.814648e-01  9.036332e-01 -3.228383e-01
+   outer loop
+     vertex  1.016981e+02  1.758290e+01 -1.134292e+01
+     vertex  1.016981e+02  2.078990e+01 -2.366419e+00
+     vertex  1.121276e+02  1.630553e+01 -5.825429e+00
+   endloop
+ endfacet
+ facet normal  3.099186e-01  8.953382e-01 -3.198748e-01
+   outer loop
+     vertex  1.016981e+02  1.758290e+01 -1.134292e+01
+     vertex  8.934905e+01  2.297715e+01 -8.208978e+00
+     vertex  1.016981e+02  2.078990e+01 -2.366419e+00
+   endloop
+ endfacet
+ facet normal  3.631060e-01  7.829626e-01 -5.050977e-01
+   outer loop
+     vertex  1.016981e+02  1.758290e+01 -1.134292e+01
+     vertex  1.121276e+02  1.630553e+01 -5.825429e+00
+     vertex  1.121276e+02  1.202950e+01 -1.245380e+01
+   endloop
+ endfacet
+ facet normal  2.236745e-01  8.190256e-01 -5.283623e-01
+   outer loop
+     vertex  1.016981e+02  1.758290e+01 -1.134292e+01
+     vertex  8.934905e+01  1.695152e+01 -1.754944e+01
+     vertex  8.934905e+01  2.297715e+01 -8.208978e+00
+   endloop
+ endfacet
+ facet normal  2.383797e-01  8.144441e-01  5.290142e-01
+   outer loop
+     vertex  7.545230e+01  2.601615e+01  9.386385e+00
+     vertex  5.997501e+01  2.577043e+01  1.673893e+01
+     vertex  7.545230e+01  1.915289e+01  1.995272e+01
+   endloop
+ endfacet
+ facet normal  2.701702e-01  9.056698e-01  3.267573e-01
+   outer loop
+     vertex  7.545230e+01  2.601615e+01  9.386385e+00
+     vertex  8.934905e+01  2.046192e+01  1.329084e+01
+     vertex  8.934905e+01  2.423425e+01  2.835123e+00
+   endloop
+ endfacet
+ facet normal  1.791856e-01  8.250469e-01  5.359012e-01
+   outer loop
+     vertex  7.545230e+01  2.601615e+01  9.386385e+00
+     vertex  7.545230e+01  1.915289e+01  1.995272e+01
+     vertex  8.934905e+01  2.046192e+01  1.329084e+01
+   endloop
+ endfacet
+ facet normal  1.447479e-01  9.307437e-01  3.358037e-01
+   outer loop
+     vertex  7.545230e+01  2.601615e+01  9.386385e+00
+     vertex  5.997501e+01  3.052142e+01  3.570648e+00
+     vertex  5.997501e+01  2.577043e+01  1.673893e+01
+   endloop
+ endfacet
+ facet normal  3.099187e-01  6.605406e-01 -6.838396e-01
+   outer loop
+     vertex  1.016981e+02  1.072684e+01 -1.796538e+01
+     vertex  8.934905e+01  1.695152e+01 -1.754944e+01
+     vertex  1.016981e+02  1.758290e+01 -1.134292e+01
+   endloop
+ endfacet
+ facet normal  3.631060e-01  4.776640e-01 -7.999945e-01
+   outer loop
+     vertex  1.016981e+02  1.072684e+01 -1.796538e+01
+     vertex  1.121276e+02  1.202950e+01 -1.245380e+01
+     vertex  1.121276e+02  5.256928e+00 -1.649760e+01
+   endloop
+ endfacet
+ facet normal  2.814648e-01  6.666603e-01 -6.901751e-01
+   outer loop
+     vertex  1.016981e+02  1.072684e+01 -1.796538e+01
+     vertex  1.016981e+02  1.758290e+01 -1.134292e+01
+     vertex  1.121276e+02  1.202950e+01 -1.245380e+01
+   endloop
+ endfacet
+ facet normal  2.145228e-01  1.500507e-01 -9.651242e-01
+   outer loop
+     vertex  1.016981e+02  1.072684e+01 -1.796538e+01
+     vertex  1.121276e+02  5.256928e+00 -1.649760e+01
+     vertex  1.121276e+02 -3.860339e-15 -1.731491e+01
+   endloop
+ endfacet
+ facet normal  2.383796e-01  9.645936e-01  1.128462e-01
+   outer loop
+     vertex  7.545230e+01  2.748018e+01 -3.127942e+00
+     vertex  5.997501e+01  3.052142e+01  3.570648e+00
+     vertex  7.545230e+01  2.601615e+01  9.386385e+00
+   endloop
+ endfacet
+ facet normal  2.701702e-01  9.566353e-01 -1.088894e-01
+   outer loop
+     vertex  7.545230e+01  2.748018e+01 -3.127942e+00
+     vertex  8.934905e+01  2.423425e+01  2.835123e+00
+     vertex  8.934905e+01  2.297715e+01 -8.208978e+00
+   endloop
+ endfacet
+ facet normal  1.791856e-01  9.771512e-01  1.143152e-01
+   outer loop
+     vertex  7.545230e+01  2.748018e+01 -3.127942e+00
+     vertex  7.545230e+01  2.601615e+01  9.386385e+00
+     vertex  8.934905e+01  2.423425e+01  2.835123e+00
+   endloop
+ endfacet
+ facet normal  1.447479e-01  9.831203e-01 -1.119040e-01
+   outer loop
+     vertex  7.545230e+01  2.748018e+01 -3.127942e+00
+     vertex  5.997501e+01  2.893819e+01 -1.033866e+01
+     vertex  5.997501e+01  3.052142e+01  3.570648e+00
+   endloop
+ endfacet
+ facet normal  2.383796e-01  9.145575e-01 -3.267412e-01
+   outer loop
+     vertex  7.545230e+01  2.324114e+01 -1.499311e+01
+     vertex  5.997501e+01  2.893819e+01 -1.033866e+01
+     vertex  7.545230e+01  2.748018e+01 -3.127942e+00
+   endloop
+ endfacet
+ facet normal  2.701702e-01  8.090668e-01 -5.219378e-01
+   outer loop
+     vertex  7.545230e+01  2.324114e+01 -1.499311e+01
+     vertex  8.934905e+01  2.297715e+01 -8.208978e+00
+     vertex  8.934905e+01  1.695152e+01 -1.754944e+01
+   endloop
+ endfacet
+ facet normal  1.447479e-01  8.314662e-01 -5.363879e-01
+   outer loop
+     vertex  7.545230e+01  2.324114e+01 -1.499311e+01
+     vertex  5.997501e+01  2.134930e+01 -2.210235e+01
+     vertex  5.997501e+01  2.893819e+01 -1.033866e+01
+   endloop
+ endfacet
+ facet normal  1.791856e-01  9.264637e-01 -3.309949e-01
+   outer loop
+     vertex  7.545230e+01  2.324114e+01 -1.499311e+01
+     vertex  7.545230e+01  2.748018e+01 -3.127942e+00
+     vertex  8.934905e+01  2.297715e+01 -8.208978e+00
+   endloop
+ endfacet
+ facet normal  1.791856e-01  6.835036e-01 -7.076125e-01
+   outer loop
+     vertex  7.545230e+01  1.417879e+01 -2.374671e+01
+     vertex  7.545230e+01  2.324114e+01 -1.499311e+01
+     vertex  8.934905e+01  1.695152e+01 -1.754944e+01
+   endloop
+ endfacet
+ facet normal  9.721944e-01 -2.232321e-01 -7.074893e-02
+   outer loop
+     vertex  1.335805e+02 -9.031689e-01 -8.696766e-01
+     vertex  1.332498e+02 -2.466832e+00 -4.795830e-01
+     vertex  1.332498e+02 -2.292746e+00 -1.028870e+00
+   endloop
+ endfacet
+ facet normal  9.607883e-01  1.228552e-01 -2.485809e-01
+   outer loop
+     vertex  1.335805e+02 -9.031689e-01 -8.696766e-01
+     vertex  1.332498e+02 -1.114733e+00 -2.252250e+00
+     vertex  1.336900e+02 -8.498654e-22 -7.654907e-06
+   endloop
+ endfacet
+ facet normal  9.680069e-01 -1.363539e-01 -2.106426e-01
+   outer loop
+     vertex  1.335805e+02 -9.031689e-01 -8.696766e-01
+     vertex  1.332498e+02 -1.598446e+00 -1.939131e+00
+     vertex  1.332498e+02 -1.114733e+00 -2.252250e+00
+   endloop
+ endfacet
+ facet normal  9.663730e-01 -1.852305e-01 -1.783616e-01
+   outer loop
+     vertex  1.335805e+02 -9.031689e-01 -8.696766e-01
+     vertex  1.332498e+02 -1.998121e+00 -1.524064e+00
+     vertex  1.332498e+02 -1.598446e+00 -1.939131e+00
+   endloop
+ endfacet
+ facet normal  9.680069e-01 -2.156424e-01 -1.283006e-01
+   outer loop
+     vertex  1.335805e+02 -9.031689e-01 -8.696766e-01
+     vertex  1.332498e+02 -2.292746e+00 -1.028870e+00
+     vertex  1.332498e+02 -1.998121e+00 -1.524064e+00
+   endloop
+ endfacet
+ facet normal  9.774051e-01 -2.107466e-01 -1.628487e-02
+   outer loop
+     vertex  1.335805e+02 -9.031689e-01 -8.696766e-01
+     vertex  1.332498e+02 -2.511225e+00  9.491712e-02
+     vertex  1.332498e+02 -2.466832e+00 -4.795830e-01
+   endloop
+ endfacet
+ facet normal  8.291894e-01 -3.219673e-01  4.569267e-01
+   outer loop
+     vertex  1.326952e+02 -2.514804e+00  2.817291e+00
+     vertex  1.319141e+02 -1.889357e+00  4.675487e+00
+     vertex  1.319141e+02 -3.767273e+00  3.352239e+00
+   endloop
+ endfacet
+ facet normal  8.665098e-01 -4.386816e-01  2.381582e-01
+   outer loop
+     vertex  1.326952e+02 -2.514804e+00  2.817291e+00
+     vertex  1.319141e+02 -3.767273e+00  3.352239e+00
+     vertex  1.319141e+02 -4.863352e+00  1.333287e+00
+   endloop
+ endfacet
+ facet normal  8.809447e-01  1.422647e-01  4.513283e-01
+   outer loop
+     vertex  1.332498e+02  9.491712e-02  2.511225e+00
+     vertex  1.319141e+02  2.571684e+00  4.337775e+00
+     vertex  1.319141e+02  3.806632e-01  5.028414e+00
+   endloop
+ endfacet
+ facet normal  8.774436e-01 -7.369190e-02  4.739854e-01
+   outer loop
+     vertex  1.332498e+02  9.491712e-02  2.511225e+00
+     vertex  1.319141e+02  3.806632e-01  5.028414e+00
+     vertex  1.319141e+02 -1.889357e+00  4.675487e+00
+   endloop
+ endfacet
+ facet normal  9.823408e-01  1.849241e-01 -2.845518e-02
+   outer loop
+     vertex  1.335805e+02  9.031689e-01  8.696766e-01
+     vertex  1.332498e+02  2.423591e+00 -6.644272e-01
+     vertex  1.332498e+02  2.511225e+00 -9.491712e-02
+   endloop
+ endfacet
+ facet normal  9.850009e-01  1.657205e-01 -4.806086e-02
+   outer loop
+     vertex  1.335805e+02  9.031689e-01  8.696766e-01
+     vertex  1.336900e+02 -8.498654e-22 -7.654907e-06
+     vertex  1.332498e+02  2.423591e+00 -6.644272e-01
+   endloop
+ endfacet
+ facet normal  9.130453e-01  2.617456e-01  3.127898e-01
+   outer loop
+     vertex  1.335805e+02  9.031689e-01  8.696766e-01
+     vertex  1.319141e+02  2.571684e+00  4.337775e+00
+     vertex  1.332498e+02  9.491712e-02  2.511225e+00
+   endloop
+ endfacet
+ facet normal  8.763716e-01  4.632133e-01  1.319327e-01
+   outer loop
+     vertex  1.326952e+02  2.817291e+00  2.514804e+00
+     vertex  1.332498e+02  2.511225e+00 -9.491712e-02
+     vertex  1.319141e+02  4.228993e+00  2.746901e+00
+   endloop
+ endfacet
+ facet normal  9.416194e-01  2.930490e-01  1.657567e-01
+   outer loop
+     vertex  1.326952e+02  2.817291e+00  2.514804e+00
+     vertex  1.335805e+02  9.031689e-01  8.696766e-01
+     vertex  1.332498e+02  2.511225e+00 -9.491712e-02
+   endloop
+ endfacet
+ facet normal  9.126382e-01  7.708790e-02  4.014337e-01
+   outer loop
+     vertex  1.326952e+02  2.817291e+00  2.514804e+00
+     vertex  1.319141e+02  2.571684e+00  4.337775e+00
+     vertex  1.335805e+02  9.031689e-01  8.696766e-01
+   endloop
+ endfacet
+ facet normal  8.260941e-01  3.902457e-01  4.065426e-01
+   outer loop
+     vertex  1.326952e+02  2.817291e+00  2.514804e+00
+     vertex  1.319141e+02  4.228993e+00  2.746901e+00
+     vertex  1.319141e+02  2.571684e+00  4.337775e+00
+   endloop
+ endfacet
+ facet normal  2.958983e-01  8.560301e-02 -9.513760e-01
+   outer loop
+     vertex  9.575624e+01  6.030747e+00 -2.186411e+01
+     vertex  1.121276e+02 -3.860339e-15 -1.731491e+01
+     vertex  8.934905e+01 -3.796736e-15 -2.439952e+01
+   endloop
+ endfacet
+ facet normal  3.539719e-01  2.902452e-01 -8.890791e-01
+   outer loop
+     vertex  9.575624e+01  6.030747e+00 -2.186411e+01
+     vertex  1.016981e+02  1.072684e+01 -1.796538e+01
+     vertex  1.121276e+02 -3.860339e-15 -1.731491e+01
+   endloop
+ endfacet
+ facet normal  2.392575e-01  1.491653e-01 -9.594298e-01
+   outer loop
+     vertex  9.575624e+01  6.030747e+00 -2.186411e+01
+     vertex  8.934905e+01 -3.796736e-15 -2.439952e+01
+     vertex  8.934905e+01  7.407867e+00 -2.324780e+01
+   endloop
+ endfacet
+ facet normal  2.834809e-01  4.916236e-01 -8.233741e-01
+   outer loop
+     vertex  9.575624e+01  6.030747e+00 -2.186411e+01
+     vertex  8.934905e+01  7.407867e+00 -2.324780e+01
+     vertex  8.934905e+01  1.695152e+01 -1.754944e+01
+   endloop
+ endfacet
+ facet normal  2.030230e-01  4.605178e-01 -8.641210e-01
+   outer loop
+     vertex  9.575624e+01  6.030747e+00 -2.186411e+01
+     vertex  8.934905e+01  1.695152e+01 -1.754944e+01
+     vertex  1.016981e+02  1.072684e+01 -1.796538e+01
+   endloop
+ endfacet
+ facet normal  2.891869e-01  4.449824e-01 -8.475621e-01
+   outer loop
+     vertex  8.260838e+01  6.926744e+00 -2.511250e+01
+     vertex  7.545230e+01  1.417879e+01 -2.374671e+01
+     vertex  8.934905e+01  1.695152e+01 -1.754944e+01
+   endloop
+ endfacet
+ facet normal  2.537935e-01  1.485973e-01 -9.557760e-01
+   outer loop
+     vertex  8.260838e+01  6.926744e+00 -2.511250e+01
+     vertex  8.934905e+01  7.407867e+00 -2.324780e+01
+     vertex  8.934905e+01 -3.796736e-15 -2.439952e+01
+   endloop
+ endfacet
+ facet normal  1.969882e-01  5.026087e-01 -8.417720e-01
+   outer loop
+     vertex  8.260838e+01  6.926744e+00 -2.511250e+01
+     vertex  8.934905e+01  1.695152e+01 -1.754944e+01
+     vertex  8.934905e+01  7.407867e+00 -2.324780e+01
+   endloop
+ endfacet
+ facet normal  2.105274e-01  3.574886e-02 -9.769341e-01
+   outer loop
+     vertex  7.545230e+01  4.935865e+00 -2.721363e+01
+     vertex  8.934905e+01 -3.796736e-15 -2.439952e+01
+     vertex  5.997501e+01 -2.677751e-15 -3.072957e+01
+   endloop
+ endfacet
+ facet normal  2.434580e-01  1.381016e-01 -9.600293e-01
+   outer loop
+     vertex  7.545230e+01  4.935865e+00 -2.721363e+01
+     vertex  8.260838e+01  6.926744e+00 -2.511250e+01
+     vertex  8.934905e+01 -3.796736e-15 -2.439952e+01
+   endloop
+ endfacet
+ facet normal  1.744881e-01  3.458087e-01 -9.219383e-01
+   outer loop
+     vertex  7.545230e+01  4.935865e+00 -2.721363e+01
+     vertex  7.545230e+01  1.417879e+01 -2.374671e+01
+     vertex  8.260838e+01  6.926744e+00 -2.511250e+01
+   endloop
+ endfacet
+ facet normal  1.760922e-01  1.417209e-01 -9.741184e-01
+   outer loop
+     vertex  6.790071e+01  7.769134e+00 -2.816653e+01
+     vertex  7.545230e+01  4.935865e+00 -2.721363e+01
+     vertex  5.997501e+01 -2.677751e-15 -3.072957e+01
+   endloop
+ endfacet
+ facet normal  1.665909e-01  1.514805e-01 -9.743209e-01
+   outer loop
+     vertex  6.790071e+01  7.769134e+00 -2.816653e+01
+     vertex  5.997501e+01 -2.677751e-15 -3.072957e+01
+     vertex  5.997501e+01  9.329714e+00 -2.927905e+01
+   endloop
+ endfacet
+ facet normal  2.424563e-01  3.407174e-01 -9.083648e-01
+   outer loop
+     vertex  6.790071e+01  7.769134e+00 -2.816653e+01
+     vertex  7.545230e+01  1.417879e+01 -2.374671e+01
+     vertex  7.545230e+01  4.935865e+00 -2.721363e+01
+   endloop
+ endfacet
+ facet normal  8.864313e-01 -3.355371e-01  3.188329e-01
+   outer loop
+     vertex  1.335805e+02 -8.696766e-01  9.031689e-01
+     vertex  1.319141e+02 -4.863352e+00  1.333287e+00
+     vertex  1.332498e+02 -2.511225e+00  9.491712e-02
+   endloop
+ endfacet
+ facet normal  0.000000e+00  0.000000e+00  0.000000e+00
+   outer loop
+     vertex  1.335805e+02 -8.696766e-01  9.031689e-01
+     vertex  1.336900e+02 -8.498654e-22 -7.654907e-06
+     vertex  1.336900e+02 -8.498654e-22 -7.654907e-06
+   endloop
+ endfacet
+ facet normal  9.799431e-01 -1.992421e-01  3.764047e-03
+   outer loop
+     vertex  1.335805e+02 -8.696766e-01  9.031689e-01
+     vertex  1.332498e+02 -2.511225e+00  9.491712e-02
+     vertex  1.335805e+02 -9.031689e-01 -8.696766e-01
+   endloop
+ endfacet
+ facet normal  9.924566e-01  2.315653e-03  1.225743e-01
+   outer loop
+     vertex  1.335805e+02 -8.696766e-01  9.031689e-01
+     vertex  1.336900e+02 -8.498654e-22 -7.654907e-06
+     vertex  1.335805e+02  9.031689e-01  8.696766e-01
+   endloop
+ endfacet
+ facet normal  9.217165e-01 -3.732337e-01  1.055237e-01
+   outer loop
+     vertex  1.335805e+02 -8.696766e-01  9.031689e-01
+     vertex  1.326952e+02 -2.514804e+00  2.817291e+00
+     vertex  1.319141e+02 -4.863352e+00  1.333287e+00
+   endloop
+ endfacet
+ facet normal  9.924565e-01 -1.225754e-01  2.315673e-03
+   outer loop
+     vertex  1.335805e+02 -8.696766e-01  9.031689e-01
+     vertex  1.335805e+02 -9.031689e-01 -8.696766e-01
+     vertex  1.336900e+02 -8.498654e-22 -7.654907e-06
+   endloop
+ endfacet
+ facet normal  9.419602e-01 -2.605059e-01  2.117727e-01
+   outer loop
+     vertex  1.334430e+02 -6.709523e-01  1.759209e+00
+     vertex  1.326952e+02 -2.514804e+00  2.817291e+00
+     vertex  1.335805e+02 -8.696766e-01  9.031689e-01
+   endloop
+ endfacet
+ facet normal  8.991867e-01 -1.238581e-01  4.196695e-01
+   outer loop
+     vertex  1.334430e+02 -6.709523e-01  1.759209e+00
+     vertex  1.319141e+02 -1.889357e+00  4.675487e+00
+     vertex  1.326952e+02 -2.514804e+00  2.817291e+00
+   endloop
+ endfacet
+ facet normal  9.002027e-01 -1.676135e-01  4.019214e-01
+   outer loop
+     vertex  1.334430e+02 -6.709523e-01  1.759209e+00
+     vertex  1.332498e+02  9.491712e-02  2.511225e+00
+     vertex  1.319141e+02 -1.889357e+00  4.675487e+00
+   endloop
+ endfacet
+ facet normal  9.761221e-01  3.580967e-02  2.142508e-01
+   outer loop
+     vertex  1.334430e+02 -6.709523e-01  1.759209e+00
+     vertex  1.335805e+02  9.031689e-01  8.696766e-01
+     vertex  1.332498e+02  9.491712e-02  2.511225e+00
+   endloop
+ endfacet
+ facet normal  9.874487e-01  2.983242e-03  1.579118e-01
+   outer loop
+     vertex  1.334430e+02 -6.709523e-01  1.759209e+00
+     vertex  1.335805e+02 -8.696766e-01  9.031689e-01
+     vertex  1.335805e+02  9.031689e-01  8.696766e-01
+   endloop
+ endfacet
+ facet normal  2.659549e-01  6.146917e-01 -7.425780e-01
+   outer loop
+     vertex  6.398324e+01  1.486027e+01 -2.603830e+01
+     vertex  5.997501e+01  2.134930e+01 -2.210235e+01
+     vertex  7.545230e+01  2.324114e+01 -1.499311e+01
+   endloop
+ endfacet
+ facet normal  2.018292e-01  3.821509e-01 -9.017903e-01
+   outer loop
+     vertex  6.398324e+01  1.486027e+01 -2.603830e+01
+     vertex  6.790071e+01  7.769134e+00 -2.816653e+01
+     vertex  5.997501e+01  9.329714e+00 -2.927905e+01
+   endloop
+ endfacet
+ facet normal  2.028340e-01  3.825833e-01 -9.013814e-01
+   outer loop
+     vertex  6.398324e+01  1.486027e+01 -2.603830e+01
+     vertex  7.545230e+01  1.417879e+01 -2.374671e+01
+     vertex  6.790071e+01  7.769134e+00 -2.816653e+01
+   endloop
+ endfacet
+ facet normal -1.316172e-02  5.126093e-01 -8.585211e-01
+   outer loop
+     vertex  6.398324e+01  1.486027e+01 -2.603830e+01
+     vertex  5.997501e+01  9.329714e+00 -2.927905e+01
+     vertex  5.997501e+01  2.134930e+01 -2.210235e+01
+   endloop
+ endfacet
+ facet normal  1.819059e-01  6.831566e-01 -7.072533e-01
+   outer loop
+     vertex  6.398324e+01  1.486027e+01 -2.603830e+01
+     vertex  7.545230e+01  2.324114e+01 -1.499311e+01
+     vertex  7.545230e+01  1.417879e+01 -2.374671e+01
+   endloop
+ endfacet
+ facet normal -1.928507e-08  9.977332e-01 -6.729388e-02
+   outer loop
+     vertex -1.449450e+02  2.000002e+01 -9.187763e-04
+     vertex -1.349999e+03  1.981807e+01 -2.698330e+00
+     vertex -1.349999e+03  2.000000e+01 -9.187413e-04
+   endloop
+ endfacet
+ facet normal -3.649603e-05  9.788076e-01 -2.047820e-01
+   outer loop
+     vertex -1.449450e+02  1.966603e+01 -3.639808e+00
+     vertex -1.349999e+03  1.923760e+01 -5.472804e+00
+     vertex -1.349999e+03  1.981807e+01 -2.698330e+00
+   endloop
+ endfacet
+ facet normal  5.423158e-05  9.958142e-01 -9.140072e-02
+   outer loop
+     vertex -1.449450e+02  1.966603e+01 -3.639808e+00
+     vertex -1.349999e+03  1.981807e+01 -2.698330e+00
+     vertex -1.449450e+02  2.000002e+01 -9.187763e-04
+   endloop
+ endfacet
+ facet normal -1.163961e-04  9.218872e-01 -3.874585e-01
+   outer loop
+     vertex -1.449450e+02  1.859573e+01 -7.362030e+00
+     vertex -1.349999e+03  1.737487e+01 -9.904831e+00
+     vertex -1.349999e+03  1.923760e+01 -5.472804e+00
+   endloop
+ endfacet
+ facet normal  7.866742e-05  9.610586e-01 -2.763447e-01
+   outer loop
+     vertex -1.449450e+02  1.859573e+01 -7.362030e+00
+     vertex -1.349999e+03  1.923760e+01 -5.472804e+00
+     vertex -1.449450e+02  1.966603e+01 -3.639808e+00
+   endloop
+ endfacet
+ facet normal -1.242360e-04  8.005980e-01 -5.992019e-01
+   outer loop
+     vertex -1.449450e+02  1.627649e+01 -1.162224e+01
+     vertex -1.349999e+03  1.440205e+01 -1.387685e+01
+     vertex -1.349999e+03  1.737487e+01 -9.904831e+00
+   endloop
+ endfacet
+ facet normal  1.191158e-04  8.782860e-01 -4.781355e-01
+   outer loop
+     vertex -1.449450e+02  1.627649e+01 -1.162224e+01
+     vertex -1.349999e+03  1.737487e+01 -9.904831e+00
+     vertex -1.449450e+02  1.859573e+01 -7.362030e+00
+   endloop
+ endfacet
+ facet normal -1.245009e-04  6.282957e-01 -7.779746e-01
+   outer loop
+     vertex -1.449450e+02  1.292412e+01 -1.526328e+01
+     vertex -1.349999e+03  1.053401e+01 -1.700069e+01
+     vertex -1.349999e+03  1.440205e+01 -1.387685e+01
+   endloop
+ endfacet
+ facet normal  1.229620e-04  7.356672e-01 -6.773431e-01
+   outer loop
+     vertex -1.449450e+02  1.292412e+01 -1.526328e+01
+     vertex -1.349999e+03  1.440205e+01 -1.387685e+01
+     vertex -1.449450e+02  1.627649e+01 -1.162224e+01
+   endloop
+ endfacet
+ facet normal -1.171963e-04  4.201882e-01 -9.074370e-01
+   outer loop
+     vertex -1.449450e+02  8.825368e+00 -1.794751e+01
+     vertex -1.349999e+03  6.142514e+00 -1.903417e+01
+     vertex -1.349999e+03  1.053401e+01 -1.700069e+01
+   endloop
+ endfacet
+ facet normal  1.195123e-04  5.478614e-01 -8.365691e-01
+   outer loop
+     vertex -1.449450e+02  8.825368e+00 -1.794751e+01
+     vertex -1.349999e+03  1.053401e+01 -1.700069e+01
+     vertex -1.449450e+02  1.292412e+01 -1.526328e+01
+   endloop
+ endfacet
+ facet normal -1.036560e-04  1.963014e-01 -9.805436e-01
+   outer loop
+     vertex -1.449450e+02  4.383690e+00 -1.951367e+01
+     vertex -1.349999e+03  1.660200e+00 -1.993152e+01
+     vertex -1.349999e+03  6.142514e+00 -1.903417e+01
+   endloop
+ endfacet
+ facet normal  1.100908e-04  3.325386e-01 -9.430896e-01
+   outer loop
+     vertex -1.449450e+02  4.383690e+00 -1.951367e+01
+     vertex -1.349999e+03  6.142514e+00 -1.903417e+01
+     vertex -1.449450e+02  8.825368e+00 -1.794751e+01
+   endloop
+ endfacet
+ facet normal -9.265823e-05 -2.602005e-02 -9.996614e-01
+   outer loop
+     vertex -1.449450e+02  4.657024e-05 -2.000000e+01
+     vertex -1.349999e+03 -2.698330e+00 -1.981807e+01
+     vertex -1.349999e+03  1.660200e+00 -1.993152e+01
+   endloop
+ endfacet
+ facet normal  9.542324e-05  1.102649e-01 -9.939022e-01
+   outer loop
+     vertex -1.449450e+02  4.657024e-05 -2.000000e+01
+     vertex -1.349999e+03  1.660200e+00 -1.993152e+01
+     vertex -1.449450e+02  4.383690e+00 -1.951367e+01
+   endloop
+ endfacet
+ facet normal -1.054608e-04 -2.491417e-01 -9.684670e-01
+   outer loop
+     vertex -1.449450e+02 -4.450508e+00 -1.949854e+01
+     vertex -1.349999e+03 -7.196304e+00 -1.866095e+01
+     vertex -1.349999e+03 -2.698330e+00 -1.981807e+01
+   endloop
+ endfacet
+ facet normal  1.006906e-04 -1.119656e-01 -9.937121e-01
+   outer loop
+     vertex -1.449450e+02 -4.450508e+00 -1.949854e+01
+     vertex -1.349999e+03 -2.698330e+00 -1.981807e+01
+     vertex -1.449450e+02  4.657024e-05 -2.000000e+01
+   endloop
+ endfacet
+ facet normal -1.096069e-04 -4.711632e-01 -8.820461e-01
+   outer loop
+     vertex -1.449450e+02 -8.677881e+00 -1.801928e+01
+     vertex -1.349999e+03 -1.150362e+01 -1.636011e+01
+     vertex -1.349999e+03 -7.196304e+00 -1.866095e+01
+   endloop
+ endfacet
+ facet normal  9.652229e-05 -3.302866e-01 -9.438807e-01
+   outer loop
+     vertex -1.449450e+02 -8.677881e+00 -1.801928e+01
+     vertex -1.349999e+03 -7.196304e+00 -1.866095e+01
+     vertex -1.449450e+02 -4.450508e+00 -1.949854e+01
+   endloop
+ endfacet
+ facet normal -9.501982e-05 -6.726045e-01 -7.400021e-01
+   outer loop
+     vertex -1.449450e+02 -1.247008e+01 -1.563640e+01
+     vertex -1.349999e+03 -1.519048e+01 -1.300904e+01
+     vertex -1.349999e+03 -1.150362e+01 -1.636011e+01
+   endloop
+ endfacet
+ facet normal  8.179821e-05 -5.320447e-01 -8.467163e-01
+   outer loop
+     vertex -1.449450e+02 -1.247008e+01 -1.563640e+01
+     vertex -1.349999e+03 -1.150362e+01 -1.636011e+01
+     vertex -1.449450e+02 -8.677881e+00 -1.801928e+01
+   endloop
+ endfacet
+ facet normal -6.189849e-05 -8.339924e-01 -5.517760e-01
+   outer loop
+     vertex -1.449450e+02 -1.563694e+01 -1.246940e+01
+     vertex -1.349999e+03 -1.791524e+01 -8.890637e+00
+     vertex -1.349999e+03 -1.519048e+01 -1.300904e+01
+   endloop
+ endfacet
+ facet normal  5.465822e-05 -7.071222e-01 -7.070914e-01
+   outer loop
+     vertex -1.449450e+02 -1.563694e+01 -1.246940e+01
+     vertex -1.349999e+03 -1.519048e+01 -1.300904e+01
+     vertex -1.449450e+02 -1.247008e+01 -1.563640e+01
+   endloop
+ endfacet
+ facet normal -2.223192e-05 -9.421454e-01 -3.352045e-01
+   outer loop
+     vertex -1.449450e+02 -1.801966e+01 -8.677096e+00
+     vertex -1.349999e+03 -1.950790e+01 -4.414220e+00
+     vertex -1.349999e+03 -1.791524e+01 -8.890637e+00
+   endloop
+ endfacet
+ facet normal  2.090897e-05 -8.467395e-01 -5.320078e-01
+   outer loop
+     vertex -1.449450e+02 -1.801966e+01 -8.677096e+00
+     vertex -1.349999e+03 -1.791524e+01 -8.890637e+00
+     vertex -1.449450e+02 -1.563694e+01 -1.246940e+01
+   endloop
+ endfacet
+ facet normal -2.528711e-06 -9.438951e-01 -3.302455e-01
+   outer loop
+     vertex -1.449450e+02 -1.949873e+01 -4.449658e+00
+     vertex -1.349999e+03 -1.950790e+01 -4.414220e+00
+     vertex -1.449450e+02 -1.801966e+01 -8.677096e+00
+   endloop
+ endfacet
+ facet normal -5.911186e-11 -9.938460e-01 -1.107710e-01
+   outer loop
+     vertex -1.449450e+02 -2.000000e+01  9.180886e-04
+     vertex -1.349999e+03 -2.000000e+01  9.187413e-04
+     vertex -1.349999e+03 -1.950790e+01 -4.414220e+00
+   endloop
+ endfacet
+ facet normal  4.270747e-06 -9.937170e-01 -1.119223e-01
+   outer loop
+     vertex -1.449450e+02 -2.000000e+01  9.180886e-04
+     vertex -1.349999e+03 -1.950790e+01 -4.414220e+00
+     vertex -1.449450e+02 -1.949873e+01 -4.449658e+00
+   endloop
+ endfacet
+ facet normal -1.000000e+00  0.000000e+00  0.000000e+00
+   outer loop
+     vertex -1.349999e+03  1.737578e+01  9.903235e+00
+     vertex -1.349999e+03  1.053557e+01  1.699972e+01
+     vertex -1.349999e+03  1.440332e+01  1.387553e+01
+   endloop
+ endfacet
+ facet normal -1.000000e+00  0.000000e+00  0.000000e+00
+   outer loop
+     vertex -1.349999e+03  2.000000e+01 -9.187413e-04
+     vertex -1.349999e+03  1.737578e+01  9.903235e+00
+     vertex -1.349999e+03  1.923811e+01  5.471036e+00
+   endloop
+ endfacet
+ facet normal -1.000000e+00  0.000000e+00  0.000000e+00
+   outer loop
+     vertex -1.349999e+03  2.000000e+01 -9.187413e-04
+     vertex -1.349999e+03  1.923811e+01  5.471036e+00
+     vertex -1.349999e+03  1.981832e+01  2.696509e+00
+   endloop
+ endfacet
+ facet normal -1.000000e+00  0.000000e+00  0.000000e+00
+   outer loop
+     vertex -1.349999e+03  1.923760e+01 -5.472804e+00
+     vertex -1.349999e+03  2.000000e+01 -9.187413e-04
+     vertex -1.349999e+03  1.981807e+01 -2.698330e+00
+   endloop
+ endfacet
+ facet normal -1.000000e+00  0.000000e+00  0.000000e+00
+   outer loop
+     vertex -1.349999e+03 -7.194590e+00  1.866161e+01
+     vertex -1.349999e+03 -2.696509e+00  1.981832e+01
+     vertex -1.349999e+03  1.662031e+00  1.993136e+01
+   endloop
+ endfacet
+ facet normal -1.000000e+00  0.000000e+00  0.000000e+00
+   outer loop
+     vertex -1.349999e+03 -7.194590e+00  1.866161e+01
+     vertex -1.349999e+03  1.662031e+00  1.993136e+01
+     vertex -1.349999e+03  6.144263e+00  1.903361e+01
+   endloop
+ endfacet
+ facet normal -1.000000e+00  0.000000e+00  0.000000e+00
+   outer loop
+     vertex -1.349999e+03 -7.194590e+00  1.866161e+01
+     vertex -1.349999e+03  6.144263e+00  1.903361e+01
+     vertex -1.349999e+03  1.053557e+01  1.699972e+01
+   endloop
+ endfacet
+ facet normal -1.000000e+00  0.000000e+00  0.000000e+00
+   outer loop
+     vertex -1.349999e+03  1.737487e+01 -9.904831e+00
+     vertex -1.349999e+03  1.737578e+01  9.903235e+00
+     vertex -1.349999e+03  2.000000e+01 -9.187413e-04
+   endloop
+ endfacet
+ facet normal -1.000000e+00  0.000000e+00  0.000000e+00
+   outer loop
+     vertex -1.349999e+03  1.737487e+01 -9.904831e+00
+     vertex -1.349999e+03  2.000000e+01 -9.187413e-04
+     vertex -1.349999e+03  1.923760e+01 -5.472804e+00
+   endloop
+ endfacet
+ facet normal -1.000000e+00  0.000000e+00  0.000000e+00
+   outer loop
+     vertex -1.349999e+03  1.053401e+01 -1.700069e+01
+     vertex -1.349999e+03  1.737487e+01 -9.904831e+00
+     vertex -1.349999e+03  1.440205e+01 -1.387685e+01
+   endloop
+ endfacet
+ facet normal -1.000000e+00  0.000000e+00  0.000000e+00
+   outer loop
+     vertex -1.349999e+03 -1.791443e+01  8.892283e+00
+     vertex -1.349999e+03 -1.518928e+01  1.301043e+01
+     vertex -1.349999e+03 -1.150212e+01  1.636116e+01
+   endloop
+ endfacet
+ facet normal -1.000000e+00  0.000000e+00  0.000000e+00
+   outer loop
+     vertex -1.349999e+03 -1.791443e+01  8.892283e+00
+     vertex -1.349999e+03 -1.150212e+01  1.636116e+01
+     vertex -1.349999e+03 -7.194590e+00  1.866161e+01
+   endloop
+ endfacet
+ facet normal -1.000000e+00  0.000000e+00  0.000000e+00
+   outer loop
+     vertex -1.349999e+03 -1.791443e+01  8.892283e+00
+     vertex -1.349999e+03  1.053557e+01  1.699972e+01
+     vertex -1.349999e+03  1.737578e+01  9.903235e+00
+   endloop
+ endfacet
+ facet normal -1.000000e+00  0.000000e+00  0.000000e+00
+   outer loop
+     vertex -1.349999e+03 -1.791443e+01  8.892283e+00
+     vertex -1.349999e+03 -7.194590e+00  1.866161e+01
+     vertex -1.349999e+03  1.053557e+01  1.699972e+01
+   endloop
+ endfacet
+ facet normal -1.000000e+00  0.000000e+00  0.000000e+00
+   outer loop
+     vertex -1.349999e+03 -1.791443e+01  8.892283e+00
+     vertex -1.349999e+03  1.737578e+01  9.903235e+00
+     vertex -1.349999e+03  1.737487e+01 -9.904831e+00
+   endloop
+ endfacet
+ facet normal -1.000000e+00  0.000000e+00  0.000000e+00
+   outer loop
+     vertex -1.349999e+03 -2.000000e+01  9.187413e-04
+     vertex -1.349999e+03 -1.950750e+01  4.416013e+00
+     vertex -1.349999e+03 -1.791443e+01  8.892283e+00
+   endloop
+ endfacet
+ facet normal -1.000000e+00  0.000000e+00  0.000000e+00
+   outer loop
+     vertex -1.349999e+03 -7.196304e+00 -1.866095e+01
+     vertex -1.349999e+03  1.660200e+00 -1.993152e+01
+     vertex -1.349999e+03 -2.698330e+00 -1.981807e+01
+   endloop
+ endfacet
+ facet normal -1.000000e+00  0.000000e+00  0.000000e+00
+   outer loop
+     vertex -1.349999e+03 -7.196304e+00 -1.866095e+01
+     vertex -1.349999e+03  6.142514e+00 -1.903417e+01
+     vertex -1.349999e+03  1.660200e+00 -1.993152e+01
+   endloop
+ endfacet
+ facet normal -1.000000e+00  0.000000e+00  0.000000e+00
+   outer loop
+     vertex -1.349999e+03 -7.196304e+00 -1.866095e+01
+     vertex -1.349999e+03  1.053401e+01 -1.700069e+01
+     vertex -1.349999e+03  6.142514e+00 -1.903417e+01
+   endloop
+ endfacet
+ facet normal -1.000000e+00  0.000000e+00  0.000000e+00
+   outer loop
+     vertex -1.349999e+03 -1.791524e+01 -8.890637e+00
+     vertex -1.349999e+03 -1.950790e+01 -4.414220e+00
+     vertex -1.349999e+03 -2.000000e+01  9.187413e-04
+   endloop
+ endfacet
+ facet normal -1.000000e+00  0.000000e+00  0.000000e+00
+   outer loop
+     vertex -1.349999e+03 -1.791524e+01 -8.890637e+00
+     vertex -1.349999e+03 -1.791443e+01  8.892283e+00
+     vertex -1.349999e+03  1.737487e+01 -9.904831e+00
+   endloop
+ endfacet
+ facet normal -1.000000e+00  0.000000e+00  0.000000e+00
+   outer loop
+     vertex -1.349999e+03 -1.791524e+01 -8.890637e+00
+     vertex -1.349999e+03  1.737487e+01 -9.904831e+00
+     vertex -1.349999e+03  1.053401e+01 -1.700069e+01
+   endloop
+ endfacet
+ facet normal -1.000000e+00  0.000000e+00  0.000000e+00
+   outer loop
+     vertex -1.349999e+03 -1.791524e+01 -8.890637e+00
+     vertex -1.349999e+03 -2.000000e+01  9.187413e-04
+     vertex -1.349999e+03 -1.791443e+01  8.892283e+00
+   endloop
+ endfacet
+ facet normal -1.000000e+00  0.000000e+00  0.000000e+00
+   outer loop
+     vertex -1.349999e+03 -1.791524e+01 -8.890637e+00
+     vertex -1.349999e+03  1.053401e+01 -1.700069e+01
+     vertex -1.349999e+03 -7.196304e+00 -1.866095e+01
+   endloop
+ endfacet
+ facet normal -1.000000e+00  0.000000e+00  0.000000e+00
+   outer loop
+     vertex -1.349999e+03 -1.150362e+01 -1.636011e+01
+     vertex -1.349999e+03 -1.791524e+01 -8.890637e+00
+     vertex -1.349999e+03 -7.196304e+00 -1.866095e+01
+   endloop
+ endfacet
+ facet normal -1.000000e+00  0.000000e+00  0.000000e+00
+   outer loop
+     vertex -1.349999e+03 -1.519048e+01 -1.300904e+01
+     vertex -1.349999e+03 -1.791524e+01 -8.890637e+00
+     vertex -1.349999e+03 -1.150362e+01 -1.636011e+01
+   endloop
+ endfacet
+ facet normal  6.092980e-11 -9.938358e-01  1.108623e-01
+   outer loop
+     vertex -1.449450e+02 -2.000000e+01  9.180886e-04
+     vertex -1.349999e+03 -1.950750e+01  4.416013e+00
+     vertex -1.349999e+03 -2.000000e+01  9.187413e-04
+   endloop
+ endfacet
+ facet normal  4.245838e-06 -9.937074e-01  1.120068e-01
+   outer loop
+     vertex -1.449450e+02 -1.949838e+01  4.451186e+00
+     vertex -1.349999e+03 -1.950750e+01  4.416013e+00
+     vertex -1.449450e+02 -2.000000e+01  9.180886e-04
+   endloop
+ endfacet
+ facet normal -2.227968e-05 -9.421146e-01  3.352910e-01
+   outer loop
+     vertex -1.449450e+02 -1.801909e+01  8.678266e+00
+     vertex -1.349999e+03 -1.791443e+01  8.892283e+00
+     vertex -1.349999e+03 -1.950750e+01  4.416013e+00
+   endloop
+ endfacet
+ facet normal -2.502990e-06 -9.438714e-01  3.303131e-01
+   outer loop
+     vertex -1.449450e+02 -1.801909e+01  8.678266e+00
+     vertex -1.349999e+03 -1.950750e+01  4.416013e+00
+     vertex -1.449450e+02 -1.949838e+01  4.451186e+00
+   endloop
+ endfacet
+ facet normal -6.195788e-05 -8.339417e-01  5.518526e-01
+   outer loop
+     vertex -1.449450e+02 -1.563630e+01  1.247021e+01
+     vertex -1.349999e+03 -1.518928e+01  1.301043e+01
+     vertex -1.349999e+03 -1.791443e+01  8.892283e+00
+   endloop
+ endfacet
+ facet normal  2.095245e-05 -8.467085e-01  5.320571e-01
+   outer loop
+     vertex -1.449450e+02 -1.563630e+01  1.247021e+01
+     vertex -1.349999e+03 -1.791443e+01  8.892283e+00
+     vertex -1.449450e+02 -1.801909e+01  8.678266e+00
+   endloop
+ endfacet
+ facet normal -9.507742e-05 -6.725365e-01  7.400639e-01
+   outer loop
+     vertex -1.449450e+02 -1.246949e+01  1.563687e+01
+     vertex -1.349999e+03 -1.150212e+01  1.636116e+01
+     vertex -1.349999e+03 -1.518928e+01  1.301043e+01
+   endloop
+ endfacet
+ facet normal  5.470602e-05 -7.070906e-01  7.071230e-01
+   outer loop
+     vertex -1.449450e+02 -1.246949e+01  1.563687e+01
+     vertex -1.349999e+03 -1.518928e+01  1.301043e+01
+     vertex -1.449450e+02 -1.563630e+01  1.247021e+01
+   endloop
+ endfacet
+ facet normal -1.096535e-04 -4.710821e-01  8.820893e-01
+   outer loop
+     vertex -1.449450e+02 -8.677438e+00  1.801949e+01
+     vertex -1.349999e+03 -7.194590e+00  1.866161e+01
+     vertex -1.349999e+03 -1.150212e+01  1.636116e+01
+   endloop
+ endfacet
+ facet normal  8.183777e-05 -5.320182e-01  8.467329e-01
+   outer loop
+     vertex -1.449450e+02 -8.677438e+00  1.801949e+01
+     vertex -1.349999e+03 -1.150212e+01  1.636116e+01
+     vertex -1.449450e+02 -1.246949e+01  1.563687e+01
+   endloop
+ endfacet
+ facet normal -1.054975e-04 -2.490528e-01  9.684899e-01
+   outer loop
+     vertex -1.449450e+02 -4.450291e+00  1.949859e+01
+     vertex -1.349999e+03 -2.696509e+00  1.981832e+01
+     vertex -1.349999e+03 -7.194590e+00  1.866161e+01
+   endloop
+ endfacet
+ facet normal  9.654839e-05 -3.302698e-01  9.438866e-01
+   outer loop
+     vertex -1.449450e+02 -4.450291e+00  1.949859e+01
+     vertex -1.349999e+03 -7.194590e+00  1.866161e+01
+     vertex -1.449450e+02 -8.677438e+00  1.801949e+01
+   endloop
+ endfacet
+ facet normal -9.269884e-05 -2.592820e-02  9.996638e-01
+   outer loop
+     vertex -1.449450e+02  2.433692e-13  2.000000e+01
+     vertex -1.349999e+03  1.662031e+00  1.993136e+01
+     vertex -1.349999e+03 -2.696509e+00  1.981832e+01
+   endloop
+ endfacet
+ facet normal  1.007116e-04 -1.119612e-01  9.937126e-01
+   outer loop
+     vertex -1.449450e+02  2.433692e-13  2.000000e+01
+     vertex -1.349999e+03 -2.696509e+00  1.981832e+01
+     vertex -1.449450e+02 -4.450291e+00  1.949859e+01
+   endloop
+ endfacet
+ facet normal -1.064111e-04  1.963915e-01  9.805256e-01
+   outer loop
+     vertex -1.449450e+02  3.639617e+00  1.966605e+01
+     vertex -1.349999e+03  6.144263e+00  1.903361e+01
+     vertex -1.349999e+03  1.662031e+00  1.993136e+01
+   endloop
+ endfacet
+ facet normal  6.930176e-05  9.137134e-02  9.958169e-01
+   outer loop
+     vertex -1.449450e+02  3.639617e+00  1.966605e+01
+     vertex -1.349999e+03  1.662031e+00  1.993136e+01
+     vertex -1.449450e+02  2.433692e-13  2.000000e+01
+   endloop
+ endfacet
+ facet normal -9.500998e-05  4.202716e-01  9.073984e-01
+   outer loop
+     vertex -1.449450e+02  7.362612e+00  1.859549e+01
+     vertex -1.349999e+03  1.053557e+01  1.699972e+01
+     vertex -1.349999e+03  6.144263e+00  1.903361e+01
+   endloop
+ endfacet
+ facet normal  7.000398e-05  2.763535e-01  9.610561e-01
+   outer loop
+     vertex -1.449450e+02  7.362612e+00  1.859549e+01
+     vertex -1.349999e+03  6.144263e+00  1.903361e+01
+     vertex -1.449450e+02  3.639617e+00  1.966605e+01
+   endloop
+ endfacet
+ facet normal -9.979236e-05  6.283671e-01  7.779169e-01
+   outer loop
+     vertex -1.449450e+02  1.162285e+01  1.627605e+01
+     vertex -1.349999e+03  1.440332e+01  1.387553e+01
+     vertex -1.349999e+03  1.053557e+01  1.699972e+01
+   endloop
+ endfacet
+ facet normal  9.599594e-05  4.781643e-01  8.782704e-01
+   outer loop
+     vertex -1.449450e+02  1.162285e+01  1.627605e+01
+     vertex -1.349999e+03  1.053557e+01  1.699972e+01
+     vertex -1.449450e+02  7.362612e+00  1.859549e+01
+   endloop
+ endfacet
+ facet normal -9.839397e-05  8.006530e-01  5.991283e-01
+   outer loop
+     vertex -1.449450e+02  1.526383e+01  1.292347e+01
+     vertex -1.349999e+03  1.737578e+01  9.903235e+00
+     vertex -1.349999e+03  1.440332e+01  1.387553e+01
+   endloop
+ endfacet
+ facet normal  9.749202e-05  6.773713e-01  7.356413e-01
+   outer loop
+     vertex -1.449450e+02  1.526383e+01  1.292347e+01
+     vertex -1.349999e+03  1.440332e+01  1.387553e+01
+     vertex -1.449450e+02  1.162285e+01  1.627605e+01
+   endloop
+ endfacet
+ facet normal -9.096666e-05  9.219227e-01  3.873738e-01
+   outer loop
+     vertex -1.449450e+02  1.794793e+01  8.824549e+00
+     vertex -1.349999e+03  1.923811e+01  5.471036e+00
+     vertex -1.349999e+03  1.737578e+01  9.903235e+00
+   endloop
+ endfacet
+ facet normal  9.317320e-05  8.365925e-01  5.478256e-01
+   outer loop
+     vertex -1.449450e+02  1.794793e+01  8.824549e+00
+     vertex -1.349999e+03  1.737578e+01  9.903235e+00
+     vertex -1.449450e+02  1.526383e+01  1.292347e+01
+   endloop
+ endfacet
+ facet normal -3.916264e-05  9.788264e-01  2.046921e-01
+   outer loop
+     vertex -1.449450e+02  1.951390e+01  4.382759e+00
+     vertex -1.349999e+03  1.981832e+01  2.696509e+00
+     vertex -1.349999e+03  1.923811e+01  5.471036e+00
+   endloop
+ endfacet
+ facet normal  8.443121e-05  9.431049e-01  3.324954e-01
+   outer loop
+     vertex -1.449450e+02  1.951390e+01  4.382759e+00
+     vertex -1.349999e+03  1.923811e+01  5.471036e+00
+     vertex -1.449450e+02  1.794793e+01  8.824549e+00
+   endloop
+ endfacet
+ facet normal -1.928129e-08  9.977394e-01  6.720221e-02
+   outer loop
+     vertex -1.449450e+02  2.000002e+01 -9.187763e-04
+     vertex -1.349999e+03  2.000000e+01 -9.187413e-04
+     vertex -1.349999e+03  1.981832e+01  2.696509e+00
+   endloop
+ endfacet
+ facet normal  9.684612e-05  9.939074e-01  1.102179e-01
+   outer loop
+     vertex -1.449450e+02  2.000002e+01 -9.187763e-04
+     vertex -1.349999e+03  1.981832e+01  2.696509e+00
+     vertex -1.449450e+02  1.951390e+01  4.382759e+00
+   endloop
+ endfacet
+endsolid

--- a/tests/test_shaft.py
+++ b/tests/test_shaft.py
@@ -8,11 +8,20 @@ class TestShaft(TestCase):
     Test case for the Shaft class.
     """
 
-    def test_generate_solid(self):
+    def test_generate_solid_01(self):
         sh = Shaft("tests/test_datasets/shaft.iges")
         shaft_solid = sh.generate_solid()
         self.assertIsInstance(shaft_solid, TopoDS_Solid)
 
-    def test_display(self):
+    def test_generate_solid_02(self):
+        sh = Shaft("tests/test_datasets/shaft.stl")
+        shaft_solid = sh.generate_solid()
+        self.assertIsInstance(shaft_solid, TopoDS_Solid)
+
+    def test_display_01(self):
         sh = Shaft("tests/test_datasets/shaft.iges")
+        sh.display()
+
+    def test_display_02(self):
+        sh = Shaft("tests/test_datasets/shaft.stl")
         sh.display()


### PR DESCRIPTION
A minor revision of the Shaft class to read a shaft file stored in .stl/.iges formats (instead of the iges format only) is proposed. This can be useful in all those cases in which an stl shaft file is preferably considerable as the input shaft file to generate a propeller.